### PR TITLE
fix: type definition. rowHeaders of IGridOptions of index.d.ts #321

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -210,7 +210,7 @@ declare namespace tuiGrid {
         heightResizable?: boolean;
         pagination?: boolean | Pagination;
         selectionUnit?: string;
-        rowHeaders?: IRowHeadersOptions;
+        rowHeaders?: string[] | IRowHeadersOptions[];
         columns: IColumnInfoOptions[];
         summary?: ISummaryObject;
         usageStatistics?: boolean;


### PR DESCRIPTION
fix: wrong type definition (ref #321)

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
The rowHeaders of IGridOptions of index.d.ts is defined differently from the document.
ref) #321 


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
