### PR TITLE
feat:  remove / setter / getter APIs

### DIFF
--- a/cypress/integration/data.spec.ts
+++ b/cypress/integration/data.spec.ts
@@ -1,4 +1,8 @@
 import { cls } from '@/helper/dom';
+import { OptRow } from '@/types';
+
+const data = [{ name: 'Kim', age: 10 }, { name: 'Lee', age: 20 }];
+const columns = [{ name: 'name' }, { name: 'age' }];
 
 before(() => {
   cy.visit('/dist');
@@ -11,9 +15,6 @@ beforeEach(() => {
 
   cy.createGrid({ data, columns });
 });
-
-const data = [{ name: 'Kim', age: 10 }, { name: 'Lee', age: 20 }];
-const columns = [{ name: 'name' }, { name: 'age' }];
 
 describe('appendRow()', () => {
   it('append a row at the end of the data', () => {
@@ -112,35 +113,57 @@ describe('resetData()', () => {
 });
 
 describe('getters', () => {
-  it('getRow() returns row matching given rowKey', () => {
-    const defaultAttr = {
-      checkDisabled: false,
-      checked: false,
-      disabled: false
+  function getRowDataWithAttrs(row: OptRow, rowNum: number) {
+    return {
+      ...row,
+      _attributes: {
+        checkDisabled: false,
+        checked: false,
+        disabled: false,
+        rowNum
+      }
     };
+  }
 
+  it('getRow() returns row matching given rowKey', () => {
     cy.gridInstance()
       .invoke('getRow', 0)
-      .should('eql', {
-        rowKey: 0,
-        name: 'Kim',
-        age: 10,
-        _attributes: {
-          ...defaultAttr,
-          rowNum: 1
-        }
-      });
+      .should('eql', getRowDataWithAttrs(data[0], 1));
 
     cy.gridInstance()
       .invoke('getRow', 1)
-      .should('eql', {
-        rowKey: 1,
-        name: 'Lee',
-        age: 20,
-        _attributes: {
-          ...defaultAttr,
-          rowNum: 2
-        }
-      });
+      .should('eql', getRowDataWithAttrs(data[1], 2));
+  });
+
+  it('getRowAt() returns row indexed by given index', () => {
+    cy.gridInstance()
+      .invoke('getRowAt', 0)
+      .should('eql', getRowDataWithAttrs(data[0], 1));
+
+    cy.gridInstance()
+      .invoke('getRowAt', 1)
+      .should('eql', getRowDataWithAttrs(data[1], 2));
+  });
+
+  it('getIndexOfRow() returns the index of the row matching given rowKey', () => {
+    cy.gridInstance()
+      .invoke('getIndexOfRow', 0)
+      .should('eql', 0);
+
+    cy.gridInstance()
+      .invoke('getIndexOfRow', 1)
+      .should('eql', 1);
+  });
+
+  it('getData() returns all rows', () => {
+    cy.gridInstance()
+      .invoke('getData')
+      .should('eql', [getRowDataWithAttrs(data[0], 1), getRowDataWithAttrs(data[1], 2)]);
+  });
+
+  it('getRowCount() returns the total number of the rows', () => {
+    cy.gridInstance()
+      .invoke('getRowCount')
+      .should('eq', 2);
   });
 });

--- a/cypress/integration/data.spec.ts
+++ b/cypress/integration/data.spec.ts
@@ -1,3 +1,5 @@
+import { cls } from '@/helper/dom';
+
 before(() => {
   cy.visit('/dist');
 });
@@ -89,5 +91,39 @@ describe('prependRow()', () => {
     cy.gridInstance().invoke('prependRow');
     cy.getCellByIdx(0, 0).should('to.have.text', '');
     cy.getCellByIdx(0, 1).should('to.have.text', '');
+  });
+});
+
+describe('removeRow()', () => {
+  it('remove a row matching given rowKey', () => {
+    cy.createGrid({ data, columns });
+
+    cy.gridInstance().invoke('removeRow', 0);
+
+    cy.getCellByIdx(0, 0).should('to.have.text', 'Lee');
+    cy.getCellByIdx(0, 1).should('to.have.text', '20');
+  });
+});
+
+describe('clear()', () => {
+  it('remove all rows', () => {
+    cy.createGrid({ data, columns });
+
+    cy.gridInstance().invoke('clear');
+
+    cy.get(`.${cls('body-area')} .${cls('cell')}`).should('not.exist');
+  });
+});
+
+describe('resetData()', () => {
+  it('reset all data', () => {
+    cy.createGrid({ data, columns });
+
+    cy.gridInstance().invoke('resetData', [{ name: 'Park', age: 30 }, { name: 'Han', age: 40 }]);
+
+    cy.getCellByIdx(0, 0).should('to.have.text', 'Park');
+    cy.getCellByIdx(0, 1).should('to.have.text', '30');
+    cy.getCellByIdx(1, 0).should('to.have.text', 'Han');
+    cy.getCellByIdx(1, 1).should('to.have.text', '40');
   });
 });

--- a/cypress/integration/data.spec.ts
+++ b/cypress/integration/data.spec.ts
@@ -8,6 +8,8 @@ beforeEach(() => {
   cy.document().then((doc) => {
     doc.body.innerHTML = '';
   });
+
+  cy.createGrid({ data, columns });
 });
 
 const data = [{ name: 'Kim', age: 10 }, { name: 'Lee', age: 20 }];
@@ -15,8 +17,6 @@ const columns = [{ name: 'name' }, { name: 'age' }];
 
 describe('appendRow()', () => {
   it('append a row at the end of the data', () => {
-    cy.createGrid({ data, columns });
-
     cy.gridInstance().invoke('appendRow', { name: 'Park', age: 30 });
 
     cy.getCellByIdx(2, 0).should('to.have.text', 'Park');
@@ -24,8 +24,6 @@ describe('appendRow()', () => {
   });
 
   it('if at option exist, insert a jrow at the given index', () => {
-    cy.createGrid({ data, columns });
-
     cy.gridInstance().invoke('appendRow', { name: 'Park', age: 30 }, { at: 1 });
 
     cy.getCellByIdx(1, 0).should('to.have.text', 'Park');
@@ -35,8 +33,6 @@ describe('appendRow()', () => {
   });
 
   it('if focus option exist, set focus to the first cell of the inserted row', () => {
-    cy.createGrid({ data, columns });
-
     cy.gridInstance().invoke('appendRow', { name: 'Park', age: 30 }, { focus: true });
 
     cy.gridInstance()
@@ -49,8 +45,6 @@ describe('appendRow()', () => {
   });
 
   it('if first argument is undefined, insert empty object', () => {
-    cy.createGrid({ data, columns });
-
     cy.gridInstance().invoke('appendRow');
     cy.getCellByIdx(2, 0).should('to.have.text', '');
     cy.getCellByIdx(2, 1).should('to.have.text', '');
@@ -59,8 +53,6 @@ describe('appendRow()', () => {
 
 describe('prependRow()', () => {
   it('insert a row at the start of the data', () => {
-    cy.createGrid({ data, columns });
-
     cy.gridInstance().invoke('prependRow', { name: 'Park', age: 30 });
 
     cy.getCellByIdx(0, 0).should('to.have.text', 'Park');
@@ -72,8 +64,6 @@ describe('prependRow()', () => {
   });
 
   it('if focus option exist, set focus to the first cell of the inserted row', () => {
-    cy.createGrid({ data, columns });
-
     cy.gridInstance().invoke('prependRow', { name: 'Park', age: 30 }, { focus: true });
 
     cy.gridInstance()
@@ -86,9 +76,8 @@ describe('prependRow()', () => {
   });
 
   it('if first argument is undefined, insert empty object', () => {
-    cy.createGrid({ data, columns });
-
     cy.gridInstance().invoke('prependRow');
+
     cy.getCellByIdx(0, 0).should('to.have.text', '');
     cy.getCellByIdx(0, 1).should('to.have.text', '');
   });
@@ -96,8 +85,6 @@ describe('prependRow()', () => {
 
 describe('removeRow()', () => {
   it('remove a row matching given rowKey', () => {
-    cy.createGrid({ data, columns });
-
     cy.gridInstance().invoke('removeRow', 0);
 
     cy.getCellByIdx(0, 0).should('to.have.text', 'Lee');
@@ -107,8 +94,6 @@ describe('removeRow()', () => {
 
 describe('clear()', () => {
   it('remove all rows', () => {
-    cy.createGrid({ data, columns });
-
     cy.gridInstance().invoke('clear');
 
     cy.get(`.${cls('body-area')} .${cls('cell')}`).should('not.exist');
@@ -117,13 +102,45 @@ describe('clear()', () => {
 
 describe('resetData()', () => {
   it('reset all data', () => {
-    cy.createGrid({ data, columns });
-
     cy.gridInstance().invoke('resetData', [{ name: 'Park', age: 30 }, { name: 'Han', age: 40 }]);
 
     cy.getCellByIdx(0, 0).should('to.have.text', 'Park');
     cy.getCellByIdx(0, 1).should('to.have.text', '30');
     cy.getCellByIdx(1, 0).should('to.have.text', 'Han');
     cy.getCellByIdx(1, 1).should('to.have.text', '40');
+  });
+});
+
+describe('getters', () => {
+  it('getRow() returns row matching given rowKey', () => {
+    const defaultAttr = {
+      checkDisabled: false,
+      checked: false,
+      disabled: false
+    };
+
+    cy.gridInstance()
+      .invoke('getRow', 0)
+      .should('eql', {
+        rowKey: 0,
+        name: 'Kim',
+        age: 10,
+        _attributes: {
+          ...defaultAttr,
+          rowNum: 1
+        }
+      });
+
+    cy.gridInstance()
+      .invoke('getRow', 1)
+      .should('eql', {
+        rowKey: 1,
+        name: 'Lee',
+        age: 20,
+        _attributes: {
+          ...defaultAttr,
+          rowNum: 2
+        }
+      });
   });
 });

--- a/cypress/integration/index.spec.ts
+++ b/cypress/integration/index.spec.ts
@@ -97,14 +97,10 @@ it('watch returns a function which stops watching', () => {
   expect(callback3).to.be.calledOnce;
 });
 
-it('array index property should not be reactive', () => {
-  const numbers = reactive([1, 2, 3]);
-  const callback = cy.stub();
-
-  watch(() => callback(numbers[0]));
-  numbers[0] = 10;
-
-  expect(callback).to.be.calledOnce;
+it('array index property cannot be reactive', () => {
+  expect(() => {
+    reactive([1, 2, 3]);
+  }).to.throw(Error, 'Array object cannot be Reactive');
 });
 
 it('notify methods should invoke watching functions', () => {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -23,7 +23,8 @@ module.exports = (on) => {
           '@': path.resolve('./src')
         }
       },
-      devtool: 'source-map',
+      // https://github.com/bahmutov/cypress-svelte-unit-test/issues/15
+      devtool: 'cheap-module-eval-source-map',
       module: {
         rules: [
           {

--- a/src/dispatch/data.ts
+++ b/src/dispatch/data.ts
@@ -7,11 +7,11 @@ import {
   RowAttributeValue
 } from '../store/types';
 import { copyDataToRange, getRangeToPaste } from '../query/clipboard';
-import { findProp, arrayEqual, mapProp } from '../helper/common';
+import { findProp, arrayEqual, mapProp, findPropIndex } from '../helper/common';
 import { getSortedData } from '../helper/sort';
 import { isColumnEditable } from '../helper/clipboard';
-import { OptRow, OptAppendRow } from '../types';
-import { createRawRow, createViewRow } from '../store/data';
+import { OptRow, OptAppendRow, OptRemoveRow } from '../types';
+import { createRawRow, createViewRow, createData } from '../store/data';
 import { notify } from '../helper/reactive';
 
 export function setValue({ data }: Store, rowKey: RowKey, columnName: string, value: CellValue) {
@@ -183,4 +183,27 @@ export function appendRow({ data, column }: Store, row: OptRow, options: OptAppe
 
   notify(data, 'rawData');
   notify(data, 'viewData');
+}
+
+export function removeRow({ data }: Store, rowKey: RowKey, options: OptRemoveRow) {
+  const { rawData, viewData } = data;
+  const rowIdx = findPropIndex('rowKey', rowKey, rawData);
+
+  rawData.splice(rowIdx, 1);
+  viewData.splice(rowIdx, 1);
+
+  notify(data, 'rawData');
+  notify(data, 'viewData');
+}
+
+export function clearData({ data }: Store) {
+  data.rawData = [];
+  data.viewData = [];
+}
+
+export function resetData({ data, column }: Store, inputData: OptRow[]) {
+  const { rawData, viewData } = createData(inputData, column);
+
+  data.rawData = rawData;
+  data.viewData = viewData;
 }

--- a/src/grid.tsx
+++ b/src/grid.tsx
@@ -19,7 +19,7 @@ import i18n from './i18n';
 import { getText } from './query/clipboard';
 import { getInvalidRows } from './query/validation';
 import { isSupportWindowClipboardData } from './helper/clipboard';
-import { findProp } from './helper/common';
+import { findPropIndex } from './helper/common';
 import { Reactive, getOriginObject } from './helper/reactive';
 
 /* eslint-disable */
@@ -555,11 +555,45 @@ export default class Grid {
    * @returns {Object} - The object that contains all values in the row.
    */
   public getRow(rowKey: RowKey) {
-    const row = findProp('rowKey', rowKey, this.store.data.rawData);
+    return this.getRowAt(this.getIndexOfRow(rowKey));
+  }
+
+  /**
+   * Returns the object that contains all values in the row at specified index.
+   * @param {number} rowIdx - The index of the row
+   * @returns {Object} - The object that contains all values in the row.
+   */
+  public getRowAt(rowIdx: number) {
+    const row = this.store.data.rawData[rowIdx];
     if (!row) {
       return null;
     }
     return getOriginObject(row as Reactive<Row>);
+  }
+
+  /**
+   * Returns the index of the row indentified by the rowKey.
+   * @param {number|string} rowKey - The unique key of the row
+   * @returns {number} - The index of the row
+   */
+  public getIndexOfRow(rowKey: RowKey) {
+    return findPropIndex('rowKey', rowKey, this.store.data.rawData);
+  }
+
+  /**
+   * Returns a list of all rows.
+   * @returns {Array} - A list of all rows
+   */
+  public getData() {
+    return this.store.data.rawData.map((row) => getOriginObject(row as Reactive<Row>));
+  }
+
+  /**
+   * Returns the total number of the rows.
+   * @returns {number} - The total number of the rows
+   */
+  public getRowCount() {
+    return this.store.data.rawData.length;
   }
 
   /**

--- a/src/grid.tsx
+++ b/src/grid.tsx
@@ -19,6 +19,8 @@ import i18n from './i18n';
 import { getText } from './query/clipboard';
 import { getInvalidRows } from './query/validation';
 import { isSupportWindowClipboardData } from './helper/clipboard';
+import { findProp } from './helper/common';
+import { Reactive, getOriginObject } from './helper/reactive';
 
 /* eslint-disable */
 if ((module as any).hot) {
@@ -545,6 +547,19 @@ export default class Grid {
    */
   public removeRow(rowKey: RowKey, options: OptRemoveRow = {}) {
     this.dispatch('removeRow', rowKey, options);
+  }
+
+  /**
+   * Returns the object that contains all values in the specified row.
+   * @param {number|string} rowKey - The unique key of the target row
+   * @returns {Object} - The object that contains all values in the row.
+   */
+  public getRow(rowKey: RowKey) {
+    const row = findProp('rowKey', rowKey, this.store.data.rawData);
+    if (!row) {
+      return null;
+    }
+    return getOriginObject(row as Reactive<Row>);
   }
 
   /**

--- a/src/grid.tsx
+++ b/src/grid.tsx
@@ -565,10 +565,7 @@ export default class Grid {
    */
   public getRowAt(rowIdx: number) {
     const row = this.store.data.rawData[rowIdx];
-    if (!row) {
-      return null;
-    }
-    return getOriginObject(row as Reactive<Row>);
+    return row ? getOriginObject(row as Reactive<Row>) : null;
   }
 
   /**

--- a/src/grid.tsx
+++ b/src/grid.tsx
@@ -5,7 +5,8 @@ import {
   OptSummaryColumnContentMap,
   OptRow,
   OptAppendRow,
-  OptPrependRow
+  OptPrependRow,
+  OptRemoveRow
 } from './types';
 import { createStore } from './store/create';
 import { Root } from './view/root';
@@ -533,5 +534,31 @@ export default class Grid {
    */
   public prependRow(row: OptRow, options: OptPrependRow = {}) {
     this.appendRow(row, { ...options, at: 0 });
+  }
+
+  /**
+   * Removes the row identified by the specified rowKey.
+   * @param {number|string} rowKey - The unique key of the row
+   * @param {boolean} [options.removeOriginalData] - If set to true, the original data will be removed.
+   * @param {boolean} [options.keepRowSpanData] - If set to true, the value of the merged cells will not be
+   *     removed although the target is first cell of them.
+   */
+  public removeRow(rowKey: RowKey, options: OptRemoveRow = {}) {
+    this.dispatch('removeRow', rowKey, options);
+  }
+
+  /**
+   * Removes all rows.
+   */
+  public clear() {
+    this.dispatch('clearData');
+  }
+
+  /**
+   * Replaces all rows with the specified list. This will not change the original data.
+   * @param {Array} data - A list of new rows
+   */
+  public resetData(data: OptRow[]) {
+    this.dispatch('resetData', data);
   }
 }

--- a/src/helper/common.ts
+++ b/src/helper/common.ts
@@ -138,6 +138,17 @@ export function isObject(obj: unknown): obj is object {
   return typeof obj === 'object' && obj !== null;
 }
 
+export function forEachObject<T, K extends Extract<keyof T, string>, V extends T[K]>(
+  fn: (value: V, key: K, obj: T) => void,
+  obj: T
+) {
+  for (const key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      fn(obj[key as K] as V, key as K, obj);
+    }
+  }
+}
+
 export function hasOwnProp<T extends object, K extends keyof T>(obj: T, key: string | K): key is K {
   return obj.hasOwnProperty(key);
 }

--- a/src/helper/reactive.ts
+++ b/src/helper/reactive.ts
@@ -6,7 +6,7 @@ interface ComputedProp<T> {
   getter: Function;
 }
 
-export type Reactive<T> = T & {
+export type Reactive<T extends Dictionary<any>> = T & {
   __storage__: T;
   __handlerMap__: Dictionary<Function[]>;
 };

--- a/src/store/data.ts
+++ b/src/store/data.ts
@@ -206,11 +206,17 @@ export function createRawRow(row: OptRow, index: number, defaultValues: Column['
   return reactive(row as Row);
 }
 
-export function create(data: OptRow[], column: Column): Reactive<Data> {
+export function createData(data: OptRow[], column: Column) {
   const { defaultValues } = column;
-
   const rawData = data.map((row, index) => createRawRow(row, index, defaultValues));
   const viewData = rawData.map((row: Row) => createViewRow(row, column.allColumnMap));
+
+  return { rawData, viewData };
+}
+
+export function create(data: OptRow[], column: Column): Reactive<Data> {
+  const { rawData, viewData } = createData(data, column);
+
   // @TODO neet to modify useClient options with net api
   const sortOptions = { columnName: 'rowKey', ascending: true, useClient: false };
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -46,6 +46,11 @@ export interface OptPrependRow {
   focus?: boolean;
 }
 
+export interface OptRemoveRow {
+  removeOriginalData?: boolean;
+  keepRowSpanData?: boolean;
+}
+
 export type OptRowHeader = string | OptColumn;
 
 interface OptValidation {

--- a/src/view/bodyRows.tsx
+++ b/src/view/bodyRows.tsx
@@ -46,8 +46,10 @@ class BodyRowsComp extends Component<Props> {
   }
 }
 
-export const BodyRows = connect<StoreProps, OwnProps>(({ viewport, column }, { side }) => ({
-  rows: viewport.rows,
-  columns: column.visibleColumnsBySide[side],
-  dummyRowCount: viewport.dummyRowCount
-}))(BodyRowsComp);
+export const BodyRows = connect<StoreProps, OwnProps>(({ viewport, column }, { side }) => {
+  return {
+    rows: viewport.rows,
+    columns: column.visibleColumnsBySide[side],
+    dummyRowCount: viewport.dummyRowCount
+  };
+})(BodyRowsComp);

--- a/src/view/hoc.tsx
+++ b/src/view/hoc.tsx
@@ -18,12 +18,22 @@ export function connect<SelectedProps = {}, OwnProps = {}>(
 
       private unwatch?: () => void;
 
+      private setStateUsingSelector(ownProps: OwnProps) {
+        if (selector) {
+          this.setState(selector(this.context.store, ownProps as DeepReadonly<OwnProps>));
+        }
+      }
+
       public componentWillMount() {
         if (selector) {
           this.unwatch = watch(() => {
-            this.setState(selector(this.context.store, this.props as DeepReadonly<OwnProps>));
+            this.setStateUsingSelector(this.props);
           });
         }
+      }
+
+      public componentWillReceiveProps(nextProps: OwnProps) {
+        this.setStateUsingSelector(nextProps);
       }
 
       public componentWillUnmount() {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
#### Added APIs
- `resetData()`
- `removeRow()` / `clear()` 
- `getRow()` / `getRowAt()` /  `getRows()` / `getIndexOfRow()` / `getRowCount()`

#### Reactive Core
- Make sure that original object is not mutated. (returns new object)
- Internal properties - `__storage__` , `__handlerMap__` - became not enumerable
- Added `getOriginObject` function
- Throws error when given object is already reactive or array type

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
