### PR TITLE
fix: init focus when remove row

### DIFF
--- a/cypress/integration/data.spec.ts
+++ b/cypress/integration/data.spec.ts
@@ -3,7 +3,7 @@ import { OptRow } from '@/types';
 import { Row } from '@/store/types';
 
 const data = [{ name: 'Kim', age: 10 }, { name: 'Lee', age: 20 }];
-const columns = [{ name: 'name' }, { name: 'age' }];
+const columns = [{ name: 'name', editor: 'text' }, { name: 'age', editor: 'text' }];
 
 before(() => {
   cy.visit('/dist');
@@ -91,6 +91,38 @@ describe('removeRow()', () => {
 
     cy.getCellByIdx(0, 0).should('to.have.text', 'Lee');
     cy.getCellByIdx(0, 1).should('to.have.text', '20');
+  });
+
+  it('remove a row when focus layer is active', () => {
+    cy.gridInstance().invoke('focus', 1, 'name', true);
+    cy.gridInstance().invoke('removeRow', 0);
+
+    cy.gridInstance()
+      .invoke('getFocusedCell')
+      .then((res) => {
+        expect(res).to.eql({ rowKey: 1, columnName: 'name', value: 'Lee' });
+      });
+    cy.getCellByIdx(0, 0).should('to.have.text', 'Lee');
+    cy.getCellByIdx(0, 1).should('to.have.text', '20');
+  });
+
+  it('remove a row when editing layer is active', () => {
+    cy.gridInstance().invoke('startEditing', 1, 'name', true);
+    cy.gridInstance().invoke('removeRow', 0);
+
+    cy.getCellByIdx(0, 0).should('to.have.text', 'Lee');
+    cy.getCellByIdx(0, 1).should('to.have.text', '20');
+    cy.get(`.${cls('layer-editing')}`).should('be.visible');
+  });
+
+  it('remove a row included focus cell', () => {
+    cy.gridInstance().invoke('focus', 0, 'name', true);
+    cy.gridInstance().invoke('removeRow', 0);
+    cy.gridInstance()
+      .invoke('getFocusedCell')
+      .then((res) => {
+        expect(res).to.eql({ rowKey: null, columnName: null, value: null });
+      });
   });
 });
 

--- a/src/dispatch/data.ts
+++ b/src/dispatch/data.ts
@@ -17,7 +17,8 @@ import {
   isUndefined,
   removeArrayItem,
   includes,
-  isEmpty
+  isEmpty,
+  someProp
 } from '../helper/common';
 import { getSortedData } from '../helper/sort';
 import { isColumnEditable } from '../helper/clipboard';
@@ -313,11 +314,11 @@ export function removeRow(
     updateRowSpanWhenRemove(rawData, removedRow[0], nextRow, options.keepRowSpanData || false);
   }
 
-  if (findPropIndex('rowKey', focus.rowKey, rawData) === -1) {
+  if (!someProp('rowKey', focus.rowKey, rawData)) {
+    focus.navigating = false;
     changeFocus(focus, data, null, null, id);
     if (focus.editingAddress && focus.editingAddress.rowKey === rowKey) {
       focus.editingAddress = null;
-      focus.navigating = true;
     }
   }
 

--- a/src/store/focus.ts
+++ b/src/store/focus.ts
@@ -1,7 +1,7 @@
 import { Focus, ColumnCoords, RowCoords, Column, Data, EditingEvent } from './types';
 import { Observable, observable } from '../helper/observable';
 import { someProp, findPropIndex } from '../helper/common';
-import { getRowSpan, enableRowSpan, getVerticalPosWithRowSpan } from '../helper/rowSpan';
+import { enableRowSpan, getVerticalPosWithRowSpan, getRowSpanByRowKey } from '../helper/rowSpan';
 
 interface FocusOption {
   data: Data;
@@ -66,7 +66,7 @@ export function create({
     },
 
     get cellPosRect(this: Focus) {
-      const { columnIndex, rowIndex, side, columnName } = this;
+      const { columnIndex, rowIndex, side, columnName, rowKey } = this;
       const { rawData, sortOptions } = data;
 
       if (columnIndex === null || rowIndex === null || side === null || columnName === null) {
@@ -77,7 +77,7 @@ export function create({
       const right = left + columnCoords.widths[side][columnIndex];
       const top = rowCoords.offsets[rowIndex];
       const bottom = top + rowCoords.heights[rowIndex];
-      const rowSpan = getRowSpan(rowIndex, columnName, rawData);
+      const rowSpan = getRowSpanByRowKey(rowKey!, columnName, rawData);
 
       if (enableRowSpan(sortOptions.columnName) && rowSpan) {
         const verticalPos = getVerticalPosWithRowSpan(columnName, rowSpan, rowCoords, rawData);

--- a/src/view/bodyCell.tsx
+++ b/src/view/bodyCell.tsx
@@ -98,10 +98,9 @@ export class BodyCellComp extends Component<Props> {
   private handleMouseMove = (ev: MouseEvent) => {
     const [pageX, pageY] = getCoordinateWithOffset(ev.pageX, ev.pageY);
     this.props.dispatch('dragMoveRowHeader', { pageX, pageY });
-    ev.stopImmediatePropagation();
   };
 
-  private handleMouseDown = (_: MouseEvent, name: string, rowKey: RowKey) => {
+  private handleMouseDown = (name: string, rowKey: RowKey) => {
     if (!isRowNumColumn(name)) {
       return;
     }
@@ -180,7 +179,7 @@ export class BodyCellComp extends Component<Props> {
         ref={(el) => {
           this.el = el;
         }}
-        onMouseDown={(ev) => this.handleMouseDown(ev, name, rowKey)}
+        onMouseDown={() => this.handleMouseDown(name, rowKey)}
       />
     );
   }
@@ -190,11 +189,11 @@ export const BodyCell = connect<StoreProps, OwnProps>(
   ({ id, column, data, selection }, { viewRow, columnInfo }) => {
     const { rowKey, valueMap, treeInfo } = viewRow;
     const { treeColumnName } = column;
-    const { disabled } = data;
+    const { disabled, viewData } = data;
     const grid = getInstance(id);
     const { range } = selection;
     const columnName = columnInfo.name;
-    const rowIndex = findPropIndex('rowKey', rowKey, data.viewData as ViewRow[]);
+    const rowIndex = findPropIndex('rowKey', rowKey, viewData as ViewRow[]);
 
     return {
       grid,

--- a/src/view/bodyCell.tsx
+++ b/src/view/bodyCell.tsx
@@ -8,6 +8,7 @@ import { CellRenderer } from '../renderer/types';
 import { getInstance } from '../instance';
 import { isRowHeader, isRowNumColumn } from '../helper/column';
 import Grid from '../grid';
+import { findPropIndex } from '../helper/common';
 
 interface OwnProps {
   viewRow: ViewRow;
@@ -97,6 +98,7 @@ export class BodyCellComp extends Component<Props> {
   private handleMouseMove = (ev: MouseEvent) => {
     const [pageX, pageY] = getCoordinateWithOffset(ev.pageX, ev.pageY);
     this.props.dispatch('dragMoveRowHeader', { pageX, pageY });
+    ev.stopImmediatePropagation();
   };
 
   private handleMouseDown = (_: MouseEvent, name: string, rowKey: RowKey) => {
@@ -192,6 +194,7 @@ export const BodyCell = connect<StoreProps, OwnProps>(
     const grid = getInstance(id);
     const { range } = selection;
     const columnName = columnInfo.name;
+    const rowIndex = findPropIndex('rowKey', rowKey, data.viewData as ViewRow[]);
 
     return {
       grid,
@@ -200,7 +203,7 @@ export const BodyCell = connect<StoreProps, OwnProps>(
       columnInfo,
       renderData: valueMap[columnName],
       ...(columnName === treeColumnName ? { treeInfo } : null),
-      selectedRow: range ? rowKey >= range.row[0] && rowKey <= range.row[1] : false
+      selectedRow: range ? rowIndex >= range.row[0] && rowIndex <= range.row[1] : false
     };
   }
 )(BodyCellComp);


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
#473
**fixed**
*  if the removed row includes focus, editing layer, initialize them.
* get row span by row key in calculating focus cell position'
* selectedRow is judged by row index not row key in the bodyCell component.

**etc**
* add cypress test case

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
