### PR TITLE
fix: change logic to invoke expanded and collapsed events (close #396)

### DIFF
--- a/src/js/model/data/treeRowList.js
+++ b/src/js/model/data/treeRowList.js
@@ -338,10 +338,10 @@ TreeRowList = RowList.extend(/** @lends module:model/data/treeRowList.prototype 
     },
 
     /**
-     * get top most row keys
+     * get root's child row keys
      * @returns {Array.<number|string>} - row keys
      */
-    getTopMostRowKeys: function() {
+    getRootChildRowKeys: function() {
         return this._rootRow._treeData.childrenRowKeys;
     },
 
@@ -418,7 +418,7 @@ TreeRowList = RowList.extend(/** @lends module:model/data/treeRowList.prototype 
      * expand all rows
      */
     treeExpandAll: function() {
-        var topMostRowKeys = this.getTopMostRowKeys();
+        var rootChildRowKeys = this.getRootChildRowKeys();
 
         /**
          * Occurs when all rows having child rows are expanded
@@ -426,8 +426,8 @@ TreeRowList = RowList.extend(/** @lends module:model/data/treeRowList.prototype 
          */
         this.trigger('expandedAll');
 
-        _.each(topMostRowKeys, function(topMostRowKey) {
-            this.treeExpand(topMostRowKey, true, true);
+        _.each(rootChildRowKeys, function(rootChildRowKey) {
+            this.treeExpand(rootChildRowKey, true, true);
         }, this);
     },
 
@@ -477,7 +477,7 @@ TreeRowList = RowList.extend(/** @lends module:model/data/treeRowList.prototype 
      * collapse all rows
      */
     treeCollapseAll: function() {
-        var topMostRowKeys = this.getTopMostRowKeys();
+        var rootChildRowKeys = this.getRootChildRowKeys();
 
         /**
          * Occurs when all rows having child rows are collapsed
@@ -485,8 +485,8 @@ TreeRowList = RowList.extend(/** @lends module:model/data/treeRowList.prototype 
          */
         this.trigger('collapsedAll');
 
-        _.each(topMostRowKeys, function(topMostRowKey) {
-            this.treeCollapse(topMostRowKey, true);
+        _.each(rootChildRowKeys, function(rootChildRowKey) {
+            this.treeCollapse(rootChildRowKey, true);
         }, this);
     },
 

--- a/src/js/model/data/treeRowList.js
+++ b/src/js/model/data/treeRowList.js
@@ -378,10 +378,9 @@ TreeRowList = RowList.extend(/** @lends module:model/data/treeRowList.prototype 
      * expand tree row
      * @param {number|string} rowKey - row key
      * @param {boolean} recursive - true for recursively expand all descendant
-     * @param {boolean} silent - true to mute event
      * @returns {Array.<number|string>} - children or descendant of given row
      */
-    treeExpand: function(rowKey, recursive, silent) {
+    treeExpand: function(rowKey, recursive) {
         var descendantRowKeys = this.getTreeDescendantRowKeys(rowKey);
         var row = this.get(rowKey);
         row.setTreeExpanded(true);
@@ -399,20 +398,18 @@ TreeRowList = RowList.extend(/** @lends module:model/data/treeRowList.prototype 
             }, this);
         }
 
-        if (!silent) {
-            /**
-             * Occurs when the row having child rows is expanded
-             * @event Grid#expanded
-             * @type {module:event/gridEvent}
-             * @property {number|string} rowKey - rowKey of the expanded row
-             * @property {Array.<number|string>} descendantRowKeys - rowKey list of all descendant rows
-             * @property {Grid} instance - Current grid instance
-             */
-            this.trigger('expanded', {
-                rowKey: rowKey,
-                descendantRowKeys: descendantRowKeys.slice(0)
-            });
-        }
+        /**
+         * Occurs when the row having child rows is expanded
+         * @event Grid#expanded
+         * @type {module:event/gridEvent}
+         * @property {number|string} rowKey - rowKey of the expanded row
+         * @property {Array.<number|string>} descendantRowKeys - rowKey list of all descendant rows
+         * @property {Grid} instance - Current grid instance
+         */
+        this.trigger('expanded', {
+            rowKey: rowKey,
+            descendantRowKeys: descendantRowKeys.slice(0)
+        });
 
         return descendantRowKeys;
     },
@@ -423,25 +420,24 @@ TreeRowList = RowList.extend(/** @lends module:model/data/treeRowList.prototype 
     treeExpandAll: function() {
         var topMostRowKeys = this.getTopMostRowKeys();
 
-        _.each(topMostRowKeys, function(topMostRowKey) {
-            this.treeExpand(topMostRowKey, true, true);
-        }, this);
-
         /**
          * Occurs when all rows having child rows are expanded
          * @event Grid#expandedAll
          */
         this.trigger('expandedAll');
+
+        _.each(topMostRowKeys, function(topMostRowKey) {
+            this.treeExpand(topMostRowKey, true, true);
+        }, this);
     },
 
     /**
      * collapse tree row
      * @param {number|string} rowKey - row key
      * @param {boolean} recursive - true for recursively expand all descendant
-     * @param {boolean} silent - true to mute event
      * @returns {Array.<number|string>} - children or descendant of given row
      */
-    treeCollapse: function(rowKey, recursive, silent) {
+    treeCollapse: function(rowKey, recursive) {
         var row = this.get(rowKey);
 
         var descendantRowKeys = this.getTreeDescendantRowKeys(rowKey);
@@ -461,20 +457,18 @@ TreeRowList = RowList.extend(/** @lends module:model/data/treeRowList.prototype 
 
         row.setTreeExpanded(false);
 
-        if (!silent) {
-            /**
-             * Occurs when the row having child rows is collapsed
-             * @event Grid#collapsed
-             * @type {module:event/gridEvent}
-             * @property {number|string} rowKey - rowKey of the collapsed row
-             * @property {Array.<number|string>} descendantRowKeys - rowKey list of all descendant rows
-             * @property {Grid} instance - Current grid instance
-             */
-            this.trigger('collapsed', {
-                rowKey: rowKey,
-                descendantRowKeys: descendantRowKeys.slice(0)
-            });
-        }
+        /**
+         * Occurs when the row having child rows is collapsed
+         * @event Grid#collapsed
+         * @type {module:event/gridEvent}
+         * @property {number|string} rowKey - rowKey of the collapsed row
+         * @property {Array.<number|string>} descendantRowKeys - rowKey list of all descendant rows
+         * @property {Grid} instance - Current grid instance
+         */
+        this.trigger('collapsed', {
+            rowKey: rowKey,
+            descendantRowKeys: descendantRowKeys.slice(0)
+        });
 
         return descendantRowKeys;
     },
@@ -485,15 +479,15 @@ TreeRowList = RowList.extend(/** @lends module:model/data/treeRowList.prototype 
     treeCollapseAll: function() {
         var topMostRowKeys = this.getTopMostRowKeys();
 
-        _.each(topMostRowKeys, function(topMostRowKey) {
-            this.treeCollapse(topMostRowKey, true, true);
-        }, this);
-
         /**
          * Occurs when all rows having child rows are collapsed
          * @event Grid#collapsedAll
          */
         this.trigger('collapsedAll');
+
+        _.each(topMostRowKeys, function(topMostRowKey) {
+            this.treeCollapse(topMostRowKey, true);
+        }, this);
     },
 
     /**

--- a/test/unit/js/model/data/treeRowList.spec.js
+++ b/test/unit/js/model/data/treeRowList.spec.js
@@ -107,13 +107,13 @@ describe('data.treeModel', function() {
         });
     });
 
-    describe('getTopMostRowKeys', function() {
+    describe('getRootChildRowKeys', function() {
         beforeEach(function() {
             treeRowList.setData(treeData, true);
         });
 
-        it('should return all top most rows', function() {
-            expect(treeRowList.getTopMostRowKeys()).toEqual([0, 5, 6]);
+        it('should return root\'s all child rows', function() {
+            expect(treeRowList.getRootChildRowKeys()).toEqual([0, 5, 6]);
         });
     });
 
@@ -455,7 +455,7 @@ describe('data.treeModel', function() {
             expect(result[2].hasTreeNextSibling()).toEqual([true, false, false]);
         });
 
-        it('should add to model list as a top most row', function() {
+        it('should add to model list as a root\'s child row', function() {
             var result;
 
             appendOptions.parentRowKey = null;
@@ -469,7 +469,7 @@ describe('data.treeModel', function() {
             expect(result[1].getTreeParentRowKey()).toBe(result[0].get('rowKey'));
             expect(result[2].getTreeParentRowKey()).toBe(result[0].get('rowKey'));
             // children
-            expect(treeRowList.getTopMostRowKeys()).toContain(result[0].get('rowKey'));
+            expect(treeRowList.getRootChildRowKeys()).toContain(result[0].get('rowKey'));
             expect(result[0].getTreeChildrenRowKeys()).toContain(result[1].get('rowKey'));
             expect(result[0].getTreeChildrenRowKeys()).toContain(result[2].get('rowKey'));
             expect(result[1].getTreeChildrenRowKeys().length).toBe(0);
@@ -532,7 +532,7 @@ describe('data.treeModel', function() {
             expect(treeRowList.length).toBe(6);
             expect(treeRowList.get(6)).not.toBeDefined();
             expect(treeRowList.get(7)).not.toBeDefined();
-            expect(treeRowList.getTopMostRowKeys()).toEqual([0, 5]);
+            expect(treeRowList.getRootChildRowKeys()).toEqual([0, 5]);
             expect(treeRowList.get(5).hasTreeNextSibling()).toEqual([false]);
         });
 

--- a/test/unit/js/model/data/treeRowList.spec.js
+++ b/test/unit/js/model/data/treeRowList.spec.js
@@ -197,24 +197,6 @@ describe('data.treeModel', function() {
 
             expect(childrenRowKeys).toEqual([1, 2, 3, 4]);
         });
-
-        it('should trigger expanded event', function() {
-            var spy = jasmine.createSpy('expanded');
-            treeRowList.on('expanded', spy);
-
-            treeRowList.treeExpand(0);
-
-            expect(spy).toHaveBeenCalled();
-        });
-
-        it('should not trigger expanded event if silent option enabled', function() {
-            var spy = jasmine.createSpy('expanded');
-            treeRowList.on('expanded', spy);
-
-            treeRowList.treeExpand(0, false, true);
-
-            expect(spy).not.toHaveBeenCalled();
-        });
     });
 
     describe('treeExpandAll', function() {
@@ -297,15 +279,6 @@ describe('data.treeModel', function() {
             treeRowList.treeCollapse(0);
 
             expect(spy).toHaveBeenCalled();
-        });
-
-        it('should not trigger collapsed event if silent option enabled', function() {
-            var spy = jasmine.createSpy('collapsed');
-            treeRowList.on('collapsed', spy);
-
-            treeRowList.treeCollapse(0, false, true);
-
-            expect(spy).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

#### Before
* Calling `expandAll` or `collapseAll` APIs prevented the `expanded` or `collapsed` events from being executed.

![스크린샷 2019-07-03 오후 5 33 55](https://user-images.githubusercontent.com/18183560/60576656-cec3ea00-9db8-11e9-8cf1-e964cc6e575c.png)

#### After
* To prevent `expanded` or `collapsed` events when calling the `expandAll` or `collapseAll` APIs, the user must explicitly block them using the `off` method.

```js
grid.on('expanded', () => {
  // ...
});

grid.on('expandedAll', () => {
  grid.off('expanded');
});
```


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
