### PR TITLE
fix: modify the point for destroying cell editor 

### DIFF
--- a/cypress/helper/customLayerEditor.ts
+++ b/cypress/helper/customLayerEditor.ts
@@ -11,7 +11,8 @@ export function createCustomLayerEditor(stub: Function) {
     public constructor(props: CellEditorProps) {
       const el = document.createElement('div');
       const layer = document.createElement('div');
-      const value = String(props.value) || '';
+      const { grid, rowKey, columnInfo, value: cellValue } = props;
+      const value = String(cellValue) || '';
 
       el.textContent = value;
 
@@ -23,7 +24,7 @@ export function createCustomLayerEditor(stub: Function) {
       });
 
       layer.addEventListener('click', () => {
-        props.grid.finishEditing(props.rowKey, props.columnInfo.name, this.getValue());
+        grid.finishEditing(rowKey, columnInfo.name, this.getValue());
       });
 
       this.el = el;

--- a/cypress/helper/customLayerEditor.ts
+++ b/cypress/helper/customLayerEditor.ts
@@ -1,0 +1,48 @@
+import { CellEditorProps, CellEditor } from '@/editor/types';
+
+export function createCustomLayerEditor(stub: Function) {
+  class CustomLayerEditor implements CellEditor {
+    public el: HTMLDivElement;
+
+    public layer: HTMLDivElement | null;
+
+    public value: string;
+
+    public constructor(props: CellEditorProps) {
+      const el = document.createElement('div');
+      const layer = document.createElement('div');
+      const value = String(props.value) || '';
+
+      el.textContent = value;
+
+      layer.className = 'custom-editor-layer';
+      layer.textContent = 'Test';
+
+      el.addEventListener('click', () => {
+        el.appendChild(layer);
+      });
+
+      layer.addEventListener('click', () => {
+        props.grid.finishEditing(props.rowKey, props.columnInfo.name, this.getValue());
+      });
+      this.el = el;
+      this.layer = layer;
+      this.value = value;
+    }
+
+    public getElement() {
+      return this.el;
+    }
+
+    public getValue() {
+      return this.value;
+    }
+
+    public beforeDestroy() {
+      this.layer = null;
+      stub();
+    }
+  }
+
+  return CustomLayerEditor;
+}

--- a/cypress/helper/customLayerEditor.ts
+++ b/cypress/helper/customLayerEditor.ts
@@ -25,6 +25,7 @@ export function createCustomLayerEditor(stub: Function) {
       layer.addEventListener('click', () => {
         props.grid.finishEditing(props.rowKey, props.columnInfo.name, this.getValue());
       });
+
       this.el = el;
       this.layer = layer;
       this.value = value;

--- a/cypress/integration/editor.spec.ts
+++ b/cypress/integration/editor.spec.ts
@@ -110,7 +110,7 @@ it('If gridEvent "stop" occurs in beforeChange, setValue does not occur.', () =>
 it('should destroy the editing layer, when only focus layer is changed.', () => {
   const stub = cy.stub();
   const CustomLayerEditor = createCustomLayerEditor(stub);
-  const data = [{ name: 'Lee', age: 20 }, { name: 'Han', age: 28 }];
+  const data = [{ name: 'Lee', age: 20 }, { name: 'Han', age: 28 }, { name: 'Ryu', age: 22 }];
   const columns = [
     {
       name: 'name',
@@ -123,19 +123,19 @@ it('should destroy the editing layer, when only focus layer is changed.', () => 
 
   cy.createGrid({ data, columns });
   cy.createStyle(`
-  .custom-editor-layer {
-    width: 300px;
-    height: 300px;
-    left: 55%;
-    top: 50%;
-    position: absolute;
-    border: 1px solid #000;
-    z-ndex: 25;
-    text-align: center;
-    line-height: 300px;
-    background-color: #fff;
-  }
-`);
+    .custom-editor-layer {
+      width: 300px;
+      height: 300px;
+      left: 55%;
+      top: 50%;
+      position: absolute;
+      border: 1px solid #000;
+      z-ndex: 25;
+      text-align: center;
+      line-height: 300px;
+      background-color: #fff;
+    }
+  `);
 
   cy.getCell(0, 'name')
     .click()

--- a/index.d.ts
+++ b/index.d.ts
@@ -570,6 +570,8 @@ declare namespace tuiGrid {
 
     public startEditingAt(rowIndex: number, columnIndex: number, setScroll?: boolean): void;
 
+    public finishEditing(rowKey: RowKey, columnName: string, value: string): void;
+
     public setValue(rowKey: RowKey, columnName: string, value: CellValue): void;
 
     public getValue(rowKey: RowKey, columnName: string): CellValue | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -191,10 +191,9 @@ declare namespace tuiGrid {
     editor?: CellEditor;
     formatter?: Formatter;
     defaultValue?: CellValue;
-    viewer?: string | boolean;
     resizable?: boolean;
     minWidth?: number;
-    escapeHTML?: false;
+    escapeHTML?: boolean;
     relations?: IRelations[];
     align?: 'left' | 'center' | 'right';
     valign?: 'top' | 'middle' | 'bottom';

--- a/src/grid.tsx
+++ b/src/grid.tsx
@@ -586,6 +586,18 @@ export default class Grid {
   }
 
   /**
+   * Sets focus on the cell at the specified index of row and column and starts to edit.
+   * @param {number|string} rowIndex - The index of the row
+   * @param {string} columnIndex - The index of the column
+   * @param {boolean} [setScroll=false] - If set to true, the view will scroll to the cell element.
+   */
+  public startEditingAt(rowIndex: number, columnIndex: number, setScroll?: boolean) {
+    const { rowKey, columnName } = getCellAddressByIndex(this.store, rowIndex, columnIndex);
+
+    this.startEditing(rowKey, columnName, setScroll);
+  }
+
+  /**
    * Sets the value of the cell identified by the specified rowKey and columnName and finish editing the cell.
    * @param {number|string} rowKey - The unique key of the row
    * @param {string} columnName - The name of the column
@@ -600,18 +612,6 @@ export default class Grid {
     }
 
     this.dispatch('finishEditing', rowKey, columnName);
-  }
-
-  /**
-   * Sets focus on the cell at the specified index of row and column and starts to edit.
-   * @param {number|string} rowIndex - The index of the row
-   * @param {string} columnIndex - The index of the column
-   * @param {boolean} [setScroll=false] - If set to true, the view will scroll to the cell element.
-   */
-  public startEditingAt(rowIndex: number, columnIndex: number, setScroll?: boolean) {
-    const { rowKey, columnName } = getCellAddressByIndex(this.store, rowIndex, columnIndex);
-
-    this.startEditing(rowKey, columnName, setScroll);
   }
 
   /**

--- a/src/grid.tsx
+++ b/src/grid.tsx
@@ -33,7 +33,12 @@ import { isSupportWindowClipboardData } from './helper/clipboard';
 import { findPropIndex, isUndefined, mapProp, findProp } from './helper/common';
 import { Observable, getOriginObject } from './helper/observable';
 import { createEventBus, EventBus } from './event/eventBus';
-import { getConditionalRows, getCellAddressByIndex, getCheckedRows } from './query/data';
+import {
+  getConditionalRows,
+  getCellAddressByIndex,
+  getCheckedRows,
+  getSortOptions
+} from './query/data';
 import { isRowHeader } from './helper/column';
 import { createProvider } from './dataSource/serverSideDataProvider';
 import { createManager } from './dataSource/modifiedDataManager';
@@ -578,6 +583,23 @@ export default class Grid {
     if (this.focus(rowKey, columnName, setScroll)) {
       this.dispatch('startEditing', rowKey, columnName);
     }
+  }
+
+  /**
+   * Sets the value of the cell identified by the specified rowKey and columnName and finish editing the cell.
+   * @param {number|string} rowKey - The unique key of the row
+   * @param {string} columnName - The name of the column
+   * @param {string} value - The value of editing result
+   */
+  public finishEditing(rowKey: RowKey, columnName: string, value: string) {
+    const sortOptions = getSortOptions(this.store);
+    this.dispatch('setValue', rowKey, columnName, value);
+
+    if (sortOptions.columnName === columnName) {
+      this.dispatch('sort', columnName, sortOptions.ascending);
+    }
+
+    this.dispatch('finishEditing', rowKey, columnName);
   }
 
   /**

--- a/src/grid.tsx
+++ b/src/grid.tsx
@@ -33,12 +33,7 @@ import { isSupportWindowClipboardData } from './helper/clipboard';
 import { findPropIndex, isUndefined, mapProp, findProp } from './helper/common';
 import { Observable, getOriginObject } from './helper/observable';
 import { createEventBus, EventBus } from './event/eventBus';
-import {
-  getConditionalRows,
-  getCellAddressByIndex,
-  getCheckedRows,
-  getSortOptions
-} from './query/data';
+import { getConditionalRows, getCellAddressByIndex, getCheckedRows } from './query/data';
 import { isRowHeader } from './helper/column';
 import { createProvider } from './dataSource/serverSideDataProvider';
 import { createManager } from './dataSource/modifiedDataManager';
@@ -604,7 +599,7 @@ export default class Grid {
    * @param {string} value - The value of editing result
    */
   public finishEditing(rowKey: RowKey, columnName: string, value: string) {
-    const sortOptions = getSortOptions(this.store);
+    const sortOptions = this.store.data.sortOptions;
     this.dispatch('setValue', rowKey, columnName, value);
 
     if (sortOptions.columnName === columnName) {

--- a/src/query/data.ts
+++ b/src/query/data.ts
@@ -42,7 +42,3 @@ export function getConditionalRows(
 
   return result;
 }
-
-export function getSortOptions({ data }: Store) {
-  return data.sortOptions;
-}

--- a/src/query/data.ts
+++ b/src/query/data.ts
@@ -42,3 +42,7 @@ export function getConditionalRows(
 
   return result;
 }
+
+export function getSortOptions({ data }: Store) {
+  return data.sortOptions;
+}

--- a/src/view/editingLayerInner.tsx
+++ b/src/view/editingLayerInner.tsx
@@ -19,8 +19,8 @@ interface StoreProps {
   grid: Grid;
   value: CellValue;
   sortOptions: SortOptions;
-  focusColumnName: string | null;
-  focusRowKey: RowKey | null;
+  focusedColumnName: string | null;
+  focusedRowKey: RowKey | null;
 }
 
 interface OwnProps {
@@ -101,10 +101,13 @@ export class EditingLayerInnerComp extends Component<Props> {
   }
 
   public componentWillReceiveProps(nextProps: Props) {
-    const { focusColumnName: prevFocusColumnName, focusRowKey: prevFocusRowKey } = this.props;
-    const { focusColumnName, focusRowKey } = nextProps;
+    const {
+      focusedColumnName: prevFocusedColumnName,
+      focusedRowKey: prevFocusedRowKey
+    } = this.props;
+    const { focusedColumnName, focusedRowKey } = nextProps;
 
-    if (focusColumnName !== prevFocusColumnName || focusRowKey !== prevFocusRowKey) {
+    if (focusedColumnName !== prevFocusedColumnName || focusedRowKey !== prevFocusedRowKey) {
       this.finishEditing(true);
     }
   }
@@ -128,7 +131,7 @@ export class EditingLayerInnerComp extends Component<Props> {
 }
 
 export const EditingLayerInner = connect<StoreProps, OwnProps>((store, { rowKey, columnName }) => {
-  const { cellPosRect, side, columnName: focusColumnName, rowKey: focusRowKey } = store.focus;
+  const { cellPosRect, side, columnName: focusedColumnName, rowKey: focusedRowKey } = store.focus;
   const {
     cellBorderWidth,
     tableBorderWidth,
@@ -159,7 +162,7 @@ export const EditingLayerInner = connect<StoreProps, OwnProps>((store, { rowKey,
     columnInfo: allColumnMap[columnName],
     value,
     sortOptions,
-    focusColumnName,
-    focusRowKey
+    focusedColumnName,
+    focusedRowKey
   };
 })(EditingLayerInnerComp);

--- a/src/view/editingLayerInner.tsx
+++ b/src/view/editingLayerInner.tsx
@@ -103,6 +103,7 @@ export class EditingLayerInnerComp extends Component<Props> {
   public componentWillReceiveProps(nextProps: Props) {
     const { focusColumnName: prevFocusColumnName, focusRowKey: prevFocusRowKey } = this.props;
     const { focusColumnName, focusRowKey } = nextProps;
+
     if (focusColumnName !== prevFocusColumnName || focusRowKey !== prevFocusRowKey) {
       this.finishEditing(true);
     }

--- a/src/view/editingLayerInner.tsx
+++ b/src/view/editingLayerInner.tsx
@@ -54,14 +54,6 @@ export class EditingLayerInnerComp extends Component<Props> {
     }
   };
 
-  private handleMouseDownDocument = (ev: MouseEvent) => {
-    const target = ev.target as HTMLElement;
-    const { contentEl } = this;
-    if (contentEl && contentEl !== target && !contentEl.contains(target)) {
-      this.finishEditing(true);
-    }
-  };
-
   private finishEditing(save: boolean) {
     if (this.editor) {
       const { dispatch, rowKey, columnName, sortOptions } = this.props;


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* The editing layer would be destroyed automatically only for changing the focused cell or pressing the enter key.
* Add `finishEditing()` API, so that users can decide the destroying point using this API.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
