### PR TITLE
fix: sync scroll for moving in selection, focus

### DIFF
--- a/src/css/grid.css
+++ b/src/css/grid.css
@@ -367,7 +367,6 @@
   top: 0;
   left: 0;
   overflow: hidden;
-  z-index: 10;
 }
 .tui-grid-lside-area .tui-grid-body-area {
   margin-right: -17px;

--- a/src/dispatch/viewport.ts
+++ b/src/dispatch/viewport.ts
@@ -1,4 +1,4 @@
-import { Rect, Store, Viewport } from '../store/types';
+import { Rect, Store, Viewport, Side } from '../store/types';
 
 function getHorizontalScrollPosition(
   rightSideWidth: number,
@@ -38,16 +38,16 @@ function getVerticalScrollPosition(
   return null;
 }
 
-function getChangedScrollPosition(store: Store, changedCellPosRect?: Rect) {
+function getChangedScrollPosition(store: Store, side: Side, changedCellPosRect?: Rect) {
   const {
     dimension: { bodyHeight, scrollXHeight, scrollYWidth, tableBorderWidth },
     columnCoords: { areaWidth },
-    focus: { cellPosRect: focusCellPostRect, side },
+    focus: { cellPosRect: focusedCellPostRect },
     viewport
   } = store;
 
   const { scrollLeft, scrollTop } = viewport;
-  const cellPosRect = changedCellPosRect || focusCellPostRect!;
+  const cellPosRect = changedCellPosRect || focusedCellPostRect!;
 
   const changedScrollLeft =
     side === 'R'
@@ -91,7 +91,7 @@ export function setScrollToFocus(store: Store) {
     return;
   }
 
-  const [changedScrollLeft, changedScrollTop] = getChangedScrollPosition(store);
+  const [changedScrollLeft, changedScrollTop] = getChangedScrollPosition(store, side);
   setScrollPosition(viewport, changedScrollTop, changedScrollLeft);
 }
 
@@ -109,15 +109,19 @@ export function setScrollToSelection(store: Store) {
   const rowIndex = inputRange.row[1];
   const columnIndex = inputRange.column[1];
   const cellSide = columnIndex > widths.L.length - 1 ? 'R' : 'L';
-  const rightSideColumnIndex = columnIndex - widths.L.length;
-
+  const rightSideColumnIndex =
+    columnIndex - widths.L.length < 0 ? widths.L.length : columnIndex - widths.L.length;
   const left = columnOffsets[cellSide][rightSideColumnIndex];
   const right = left + widths[cellSide][rightSideColumnIndex];
   const top = rowOffsets[rowIndex];
   const bottom = top + heights[rowIndex];
 
   const cellPosRect = { left, right, top, bottom };
-  const [changedScrollLeft, changedScrollTop] = getChangedScrollPosition(store, cellPosRect);
+  const [changedScrollLeft, changedScrollTop] = getChangedScrollPosition(
+    store,
+    cellSide,
+    cellPosRect
+  );
   setScrollPosition(viewport, changedScrollTop, changedScrollLeft);
 }
 

--- a/src/dispatch/viewport.ts
+++ b/src/dispatch/viewport.ts
@@ -110,7 +110,7 @@ export function setScrollToSelection(store: Store) {
   const columnIndex = inputRange.column[1];
   const cellSide = columnIndex > widths.L.length - 1 ? 'R' : 'L';
   const rightSideColumnIndex =
-    columnIndex - widths.L.length < 0 ? widths.L.length : columnIndex - widths.L.length;
+    columnIndex < widths.L.length ? widths.L.length : columnIndex - widths.L.length;
   const left = columnOffsets[cellSide][rightSideColumnIndex];
   const right = left + widths[cellSide][rightSideColumnIndex];
   const top = rowOffsets[rowIndex];


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* sync the scroll with focus, selection.
* remove left-side z-index css property to prevent hiding the bottom of the focus layer.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
