### PR TITLE
fix: getModifiedRows method

### DIFF
--- a/cypress/integration/dataSource.spec.ts
+++ b/cypress/integration/dataSource.spec.ts
@@ -4,7 +4,6 @@ import { data as sortedSampleData } from '../../samples/dataSource/sortedData';
 import { runMockServer } from '../helper/runMockServer';
 import { isSubsetOf } from '../helper/compare';
 import { Dictionary } from '@/store/types';
-import GridEvent from '@/event/gridEvent';
 
 const columns = [
   { name: 'id', minWidth: 150, sortable: true },

--- a/cypress/integration/modifiedDataManager.spec.ts
+++ b/cypress/integration/modifiedDataManager.spec.ts
@@ -1,0 +1,96 @@
+export {};
+
+interface Data {
+  name: string;
+  age: number;
+}
+
+interface ModifiedRowsLengthMap {
+  createdRows: number;
+  updatedRows: number;
+  deletedRows: number;
+}
+
+interface ModifiedRowsMap {
+  createdRows?: Data[];
+  updatedRows?: Data[];
+  deletedRows?: Data[];
+}
+
+const data = [{ name: 'Kim', age: 10 }, { name: 'Lee', age: 20 }];
+const columns = [{ name: 'name', editor: 'text' }, { name: 'age', editor: 'text' }];
+
+before(() => {
+  cy.visit('/dist');
+});
+
+beforeEach(() => {
+  cy.document().then((doc) => {
+    doc.body.innerHTML = '';
+  });
+
+  cy.createGrid({ data, columns });
+});
+
+function assertModifiedRowsLength(lengthMap: ModifiedRowsLengthMap) {
+  cy.gridInstance()
+    .invoke('getModifiedRows')
+    .should((rows) => {
+      Cypress.$.each(rows, (type: keyof ModifiedRowsLengthMap) => {
+        expect(rows[type]).to.have.length(lengthMap[type]);
+      });
+    });
+}
+
+function assertModifiedRowsContainsObject(modifiedRowsMap: ModifiedRowsMap) {
+  cy.gridInstance()
+    .invoke('getModifiedRows')
+    .should((rows) => {
+      Cypress.$.each(modifiedRowsMap, (type: keyof ModifiedRowsMap) => {
+        const targetModifiedRows = rows[type];
+        modifiedRowsMap[type]!.forEach((row, index) => {
+          expect(targetModifiedRows[index]).to.contain(row);
+        });
+      });
+    });
+}
+
+it('should add new row to createdRows property after appending a row', () => {
+  cy.gridInstance().invoke('appendRow', { name: 'Park', age: 30 });
+
+  assertModifiedRowsLength({ createdRows: 1, updatedRows: 0, deletedRows: 0 });
+  assertModifiedRowsContainsObject({ createdRows: [{ name: 'Park', age: 30 }] });
+});
+
+it('should not add the created row to updatedRows, regardless of modifying it', () => {
+  cy.gridInstance().invoke('appendRow', { name: 'Park', age: 30 });
+  cy.gridInstance().invoke('setValue', 2, 'name', 'RYU');
+
+  assertModifiedRowsLength({ createdRows: 1, updatedRows: 0, deletedRows: 0 });
+  assertModifiedRowsContainsObject({ createdRows: [{ name: 'RYU', age: 30 }] });
+});
+
+it('should add updated row to updateRows property once, regardless of modifying it in many times', () => {
+  cy.gridInstance().invoke('appendRow', { name: 'Park', age: 30 });
+  cy.gridInstance().invoke('setValue', 2, 'age', 20);
+  cy.gridInstance().invoke('setValue', 0, 'name', 'RYU');
+  cy.gridInstance().invoke('setValue', 0, 'name', 'JIN');
+
+  assertModifiedRowsLength({ createdRows: 1, updatedRows: 1, deletedRows: 0 });
+  assertModifiedRowsContainsObject({
+    createdRows: [{ name: 'Park', age: 20 }],
+    updatedRows: [{ name: 'JIN', age: 10 }]
+  });
+});
+
+it('should add deleted row to only deletedRows property, regardless of modifying it before', () => {
+  cy.gridInstance().invoke('appendRow', { name: 'Park', age: 30 });
+  cy.gridInstance().invoke('setValue', 2, 'age', 20);
+  cy.gridInstance().invoke('setValue', 0, 'name', 'RYU');
+  cy.gridInstance().invoke('setValue', 0, 'name', 'JIN');
+  cy.gridInstance().invoke('removeRow', 0);
+  cy.gridInstance().invoke('removeRow', 2);
+
+  assertModifiedRowsLength({ createdRows: 0, updatedRows: 0, deletedRows: 1 });
+  assertModifiedRowsContainsObject({ deletedRows: [{ name: 'JIN', age: 10 }] });
+});

--- a/src/dataSource/modifiedDataManager.ts
+++ b/src/dataSource/modifiedDataManager.ts
@@ -90,15 +90,20 @@ export function createManager(): ModifiedDataManager {
 
     push(type: ModificationTypeCode, row: Row) {
       const { rowKey } = row;
-      // filter duplicated row
-      if (type === 'UPDATE') {
-        splice('CREATE', rowKey, row);
-        splice('UPDATE', rowKey, row);
-      }
-      if (type === 'DELETE') {
-        splice('CREATE', rowKey);
+      if (type === 'UPDATE' || type === 'DELETE') {
         splice('UPDATE', rowKey);
+        // if the row was already registered in createdRows,
+        // would update it in createdRows and not add it to updatedRows or deletedRows
+        if (someProp('rowKey', rowKey, dataMap.CREATE)) {
+          if (type === 'UPDATE') {
+            splice('CREATE', rowKey, row);
+          } else {
+            splice('CREATE', rowKey);
+          }
+          return;
+        }
       }
+
       if (!someProp('rowKey', rowKey, dataMap[type])) {
         dataMap[type].push(row);
       }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* fixed that the duplicated data is added to createdRows and updatedRows on modifying the created data(#502).


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
