### PR TITLE
feat: bind tree data source

### DIFF
--- a/cypress/integration/tree.spec.ts
+++ b/cypress/integration/tree.spec.ts
@@ -59,6 +59,10 @@ beforeEach(() => {
               _children: [
                 {
                   c1: 'qux'
+                },
+                {
+                  c1: 'quxx',
+                  _children: []
                 }
               ]
             }
@@ -181,18 +185,8 @@ describe('treeColumnOptions', () => {
 });
 
 describe('toggle button', () => {
-  it(`is created when row data has children.`, () => {
+  it(`is created when row data has '_children' property.`, () => {
     cy.gridInstance().invoke('expand', 0, true);
-    cy.getCell(0, 'c1').within(() => {
-      cy.get(`.${cls('btn-tree')}`)
-        .its('length')
-        .should('be.eql', 1);
-    });
-    cy.getCell(1, 'c1').within(() => {
-      cy.get(`.${cls('btn-tree')}`)
-        .its('length')
-        .should('be.eql', 1);
-    });
     cy.getCell(2, 'c1').within(() => {
       cy.get(`.${cls('btn-tree')}`)
         .its('length')
@@ -200,6 +194,11 @@ describe('toggle button', () => {
     });
     cy.getCell(3, 'c1').within(() => {
       cy.get(`.${cls('btn-tree')}`).should('not.exist');
+    });
+    cy.getCell(4, 'c1').within(() => {
+      cy.get(`.${cls('btn-tree')}`)
+        .its('length')
+        .should('be.eql', 1);
     });
   });
 
@@ -334,8 +333,8 @@ describe('appendRow()', () => {
     cy.gridInstance().invoke('appendRow', appendedData);
     cy.gridInstance().invoke('expandAll');
 
-    cy.getCell(4, 'c1').should('be.visible');
-    cy.getCell(4, 'c1').should('have.text', 'test');
+    cy.getCell(5, 'c1').should('be.visible');
+    cy.getCell(5, 'c1').should('have.text', 'test');
   });
 
   it('appends internal row on root.', () => {
@@ -376,21 +375,33 @@ describe('appendTreeRow()', () => {
       _children: [{ c1: 'b' }, { c1: 'c' }]
     };
 
+    it('root.', () => {
+      cy.gridInstance().invoke('appendRow', appendedData);
+      cy.gridInstance().invoke('expandAll');
+
+      cy.getCell(5, 'c1').should('be.visible');
+      cy.getCell(6, 'c1').should('be.visible');
+      cy.getCell(7, 'c1').should('be.visible');
+      cy.getCell(5, 'c1').should('have.text', 'a');
+      cy.getCell(6, 'c1').should('have.text', 'b');
+      cy.getCell(7, 'c1').should('have.text', 'c');
+    });
+
     it('specific parent that internal type.', () => {
       cy.gridInstance().invoke('appendTreeRow', appendedData, { parentRowKey: 0 });
       cy.gridInstance().invoke('expand', 0, true);
 
-      cy.getCell(4, 'c1').should('be.visible');
       cy.getCell(5, 'c1').should('be.visible');
       cy.getCell(6, 'c1').should('be.visible');
-      cy.getCell(4, 'c1').should('have.text', 'a');
-      cy.getCell(5, 'c1').should('have.text', 'b');
-      cy.getCell(6, 'c1').should('have.text', 'c');
+      cy.getCell(7, 'c1').should('be.visible');
+      cy.getCell(5, 'c1').should('have.text', 'a');
+      cy.getCell(6, 'c1').should('have.text', 'b');
+      cy.getCell(7, 'c1').should('have.text', 'c');
 
       cy.gridInstance().invoke('collapse', 0);
-      cy.getCell(4, 'c1').should('be.not.visible');
       cy.getCell(5, 'c1').should('be.not.visible');
       cy.getCell(6, 'c1').should('be.not.visible');
+      cy.getCell(7, 'c1').should('be.not.visible');
     });
 
     it('specific parent that collapsed.', () => {
@@ -398,10 +409,10 @@ describe('appendTreeRow()', () => {
       cy.gridInstance().invoke('expand', 0);
       cy.gridInstance().invoke('expand', 2);
 
-      cy.getCell(4, 'c1').should('have.text', 'a');
-      cy.getCell(4, 'c1').should('be.visible');
-      cy.getCell(5, 'c1').should('be.not.visible');
+      cy.getCell(5, 'c1').should('have.text', 'a');
+      cy.getCell(5, 'c1').should('be.visible');
       cy.getCell(6, 'c1').should('be.not.visible');
+      cy.getCell(7, 'c1').should('be.not.visible');
     });
   });
 
@@ -520,7 +531,7 @@ describe('removeTreeRow()', () => {
   });
 
   context('parent row', () => {
-    it('that has only one child is changed to leaf row.', () => {
+    it('is changed to leaf row when all child rows.', () => {
       cy.gridInstance().invoke('expand', 0, true);
 
       assertInternalRow(2);
@@ -528,7 +539,7 @@ describe('removeTreeRow()', () => {
       assertLeafRow(2);
     });
 
-    it('that has children is not changed to leaf row.', () => {
+    it('is not changed to leaf row when having child rows.', () => {
       cy.gridInstance().invoke('expand', 0, true);
 
       assertInternalRow(1);
@@ -545,7 +556,7 @@ it('attachs tree rows only expanded to DOM element.', () => {
   cy.get(`.${cls('rside-area')} .${cls('body-area')} tr`).should('have.length', 3);
 
   cy.gridInstance().invoke('expand', 2);
-  cy.get(`.${cls('rside-area')} .${cls('body-area')} tr`).should('have.length', 4);
+  cy.get(`.${cls('rside-area')} .${cls('body-area')} tr`).should('have.length', 5);
 });
 
 describe('modified data is added', () => {
@@ -573,6 +584,6 @@ describe('modified data is added', () => {
     cy.gridInstance().invoke('expand', 0, true);
     cy.gridInstance().invoke('removeRow', 0);
 
-    assertModifiedRowsLength('deletedRows', 4);
+    assertModifiedRowsLength('deletedRows', 5);
   });
 });

--- a/cypress/integration/tree.spec.ts
+++ b/cypress/integration/tree.spec.ts
@@ -347,12 +347,12 @@ describe('appendRow()', () => {
     cy.gridInstance().invoke('appendRow', appendedData);
     cy.gridInstance().invoke('expandAll');
 
-    cy.getCell(4, 'c1').should('be.visible');
     cy.getCell(5, 'c1').should('be.visible');
     cy.getCell(6, 'c1').should('be.visible');
-    cy.getCell(4, 'c1').should('have.text', 'a');
-    cy.getCell(5, 'c1').should('have.text', 'b');
-    cy.getCell(6, 'c1').should('have.text', 'c');
+    cy.getCell(7, 'c1').should('be.visible');
+    cy.getCell(5, 'c1').should('have.text', 'a');
+    cy.getCell(6, 'c1').should('have.text', 'b');
+    cy.getCell(7, 'c1').should('have.text', 'c');
   });
 });
 
@@ -363,11 +363,11 @@ describe('appendTreeRow()', () => {
     cy.gridInstance().invoke('appendTreeRow', appendedData, { parentRowKey: 0 });
     cy.gridInstance().invoke('expandAll');
 
-    cy.getCell(4, 'c1').should('be.visible');
-    cy.getCell(4, 'c1').should('have.text', 'test');
+    cy.getCell(5, 'c1').should('be.visible');
+    cy.getCell(5, 'c1').should('have.text', 'test');
 
     cy.gridInstance().invoke('collapse', 0);
-    cy.getCell(4, 'c1').should('be.not.visible');
+    cy.getCell(5, 'c1').should('be.not.visible');
   });
 
   context('appends internal row to', () => {
@@ -533,16 +533,13 @@ describe('removeTreeRow()', () => {
 
   context('parent row', () => {
     it('is changed to leaf row when all child rows.', () => {
-      cy.gridInstance().invoke('expand', 0, true);
-
       assertInternalRow(2);
       cy.gridInstance().invoke('removeTreeRow', 3);
+      cy.gridInstance().invoke('removeTreeRow', 4);
       assertLeafRow(2);
     });
 
     it('is not changed to leaf row when having child rows.', () => {
-      cy.gridInstance().invoke('expand', 0, true);
-
       assertInternalRow(1);
       cy.gridInstance().invoke('removeTreeRow', 3);
       assertInternalRow(1);

--- a/examples/data/tree-dummy.js
+++ b/examples/data/tree-dummy.js
@@ -46,8 +46,7 @@ const treeData = [
         listenCount: 5000,
         _attributes: {
           expanded: false
-        },
-        _children: []
+        }
       },
       {
         id: 450720,

--- a/examples/data/tree-dummy.js
+++ b/examples/data/tree-dummy.js
@@ -28,7 +28,8 @@ const treeData = [
         grade: '5',
         price: 12000,
         downloadCount: 1000,
-        listenCount: 5000
+        listenCount: 5000,
+        _children: []
       },
       {
         id: 498896,

--- a/examples/example14-tree.html
+++ b/examples/example14-tree.html
@@ -35,8 +35,7 @@
       {
         header: 'Name',
         name: 'name',
-        width: 300,
-        editor: 'text'
+        width: 300
       },
       {
         header: 'Artist',
@@ -62,6 +61,21 @@
 
       console.log('rowKey: ' + rowKey);
       console.log('descendantRows: ' + descendantRows);
+
+      if (!descendantRows.length) {
+        grid.appendRow({
+          name: 'dynamic loading data',
+          _children: [
+            {
+              name: 'leaf row'
+            },
+            {
+              name: 'internal row',
+              _children: []
+            }
+          ]
+        }, { parentRowKey: rowKey });
+      }
     });
 
     grid.on('collapse', (ev) => {

--- a/samples/tree.ts
+++ b/samples/tree.ts
@@ -28,7 +28,8 @@ export const data = [
         grade: '5',
         price: 6000,
         downloadCount: 1000,
-        listenCount: 5000
+        listenCount: 5000,
+        _children: []
       },
       {
         id: 491379,

--- a/src/dataSource/serverSideDataProvider.ts
+++ b/src/dataSource/serverSideDataProvider.ts
@@ -11,7 +11,9 @@ import {
 import { Store, Dictionary, Row, RowKey } from '../store/types';
 import { OptRow } from '../types';
 import { Dispatch } from '../dispatch/create';
-import { isUndefined, isObject } from '../helper/common';
+import { removeExpandedAttr } from '../dispatch/tree';
+import { getChildRowKeys } from '../helper/tree';
+import { isUndefined, isObject, findProp } from '../helper/common';
 import GridAjax from './gridAjax';
 import { getEventBus } from '../event/eventBus';
 import { getDataManager } from '../instance';
@@ -98,6 +100,12 @@ class ServerSideDataProvider implements DataProvider {
         parentRowKey
       });
     });
+
+    const row = findProp('rowKey', parentRowKey, this.store.data.rawData);
+
+    if (row && !getChildRowKeys(row).length) {
+      removeExpandedAttr(row);
+    }
   };
 
   public readData(page: number, data = {}, resetData = false) {

--- a/src/dataSource/serverSideDataProvider.ts
+++ b/src/dataSource/serverSideDataProvider.ts
@@ -84,11 +84,28 @@ class ServerSideDataProvider implements DataProvider {
     this.dispatch('setPagination', data.pagination);
   };
 
+  private handleSuccessReadTreeData = (response: Response) => {
+    const { result, data } = response;
+
+    if (!result || isUndefined(data)) {
+      return;
+    }
+
+    const { parentRowKey } = this.lastRequiredData;
+
+    data.contents.forEach((row) => {
+      this.dispatch('appendTreeRow', row, {
+        parentRowKey
+      });
+    });
+  };
+
   public readData(page: number, data = {}, resetData = false) {
     if (!this.api) {
       return;
     }
     const { api, withCredentials } = this;
+    const { treeColumnName } = this.store.column;
     const { perPage } = this.store.data.pageOptions;
     const { method, url } = api.readData;
     const dataWithType = data as Params;
@@ -96,13 +113,21 @@ class ServerSideDataProvider implements DataProvider {
     const params = resetData
       ? { perPage, ...dataWithType, page }
       : { ...this.lastRequiredData, ...dataWithType, page };
+    let handleSuccessReadData = this.handleSuccessReadData;
+
+    if (treeColumnName && !isUndefined(dataWithType.parentRowKey)) {
+      handleSuccessReadData = this.handleSuccessReadTreeData;
+      delete params.page;
+      delete params.perPage;
+    }
+
     this.lastRequiredData = params;
 
     const request = new GridAjax({
       method,
       url,
       params,
-      callback: this.handleSuccessReadData,
+      callback: handleSuccessReadData,
       callbackWhenever: () => this.dispatch('setRenderState', 'DONE'),
       withCredentials,
       eventBus: getEventBus(this.store.id)

--- a/src/dispatch/tree.ts
+++ b/src/dispatch/tree.ts
@@ -15,7 +15,6 @@ import {
   removeChildRowKey,
   isLeaf,
   isExpanded,
-  isHiddenRow,
   isRootChildRow
 } from '../helper/tree';
 import { getEventBus } from '../event/eventBus';
@@ -29,11 +28,11 @@ function changeExpandedAttr(row: Row, expanded: boolean) {
   }
 }
 
-function changeHiddenChildAttr(row: Row, hidden: boolean) {
+function changeHiddenAttr(row: Row, hidden: boolean) {
   const { tree } = row._attributes;
 
   if (tree) {
-    tree.hiddenChild = hidden;
+    tree.hidden = hidden;
   }
 }
 
@@ -70,7 +69,6 @@ function expand(store: Store, row: Row, recursive?: boolean) {
 
   changeExpandedAttr(row, true);
 
-  const hiddenRow = isHiddenRow(row);
   const childRowKeys = getChildRowKeys(row);
 
   childRowKeys.forEach((childRowKey) => {
@@ -80,7 +78,7 @@ function expand(store: Store, row: Row, recursive?: boolean) {
       return;
     }
 
-    changeHiddenChildAttr(childRow, hiddenRow);
+    changeHiddenAttr(childRow, false);
 
     if (!isLeaf(childRow) && (isExpanded(childRow) || recursive)) {
       expand(store, childRow, recursive);
@@ -133,7 +131,6 @@ function collapse(store: Store, row: Row, recursive?: boolean) {
 
   changeExpandedAttr(row, false);
 
-  const hiddenRow = isHiddenRow(row);
   const childRowKeys = getChildRowKeys(row);
 
   childRowKeys.forEach((childRowKey) => {
@@ -143,7 +140,7 @@ function collapse(store: Store, row: Row, recursive?: boolean) {
       return;
     }
 
-    changeHiddenChildAttr(childRow, hiddenRow);
+    changeHiddenAttr(childRow, true);
 
     if (!isLeaf(childRow)) {
       if (recursive) {

--- a/src/dispatch/tree.ts
+++ b/src/dispatch/tree.ts
@@ -37,7 +37,7 @@ function changeHiddenChildAttr(row: Row, hidden: boolean) {
   }
 }
 
-function removeExpandedAttr(row: Row) {
+export function removeExpandedAttr(row: Row) {
   const { tree } = row._attributes;
 
   if (tree) {

--- a/src/grid.tsx
+++ b/src/grid.tsx
@@ -949,7 +949,7 @@ export default class Grid {
     this.dispatch('setRowCheckDisabled', false, rowKey);
   }
 
-  /*
+  /**
    * Inserts the new row with specified data to the end of table.
    * @param {Object} [row] - The data for the new row
    * @param {Object} [options] - Options

--- a/src/helper/tree.ts
+++ b/src/helper/tree.ts
@@ -66,29 +66,25 @@ export function isExpanded(row: Row) {
   return !!tree && tree.expanded;
 }
 
-export function getDepth(rawData: Row[], row: Row) {
-  let parentRow: Row | undefined = row;
+export function isRootChildRow(row: Row) {
+  const { tree } = row._attributes;
+
+  return !!tree && isNull(tree.parentRowKey);
+}
+
+export function getDepth(rawData: Row[], row?: Row) {
+  let parentRow = row;
   let depth = 0;
 
   do {
     depth += 1;
-    parentRow = findProp('rowKey', getParentRowKey(parentRow), rawData);
+    parentRow = findProp('rowKey', getParentRowKey(parentRow!), rawData);
   } while (parentRow);
 
   return depth;
 }
 
-function getExpandedState(row: OptRow) {
-  if (row && row._attributes) {
-    const { expanded = false } = row._attributes;
-
-    return expanded;
-  }
-
-  return false;
-}
-
-export function getHiddenChildState(row: Row) {
+export function isHiddenRow(row: Row) {
   if (row) {
     const { tree } = row._attributes;
     const collapsed = !isExpanded(row);
@@ -124,8 +120,8 @@ function createTreeRawRow(
 
   rawRow._attributes.tree = observable({
     ...defaultAttributes,
-    ...(Array.isArray(row._children) && { expanded: getExpandedState(row) }),
-    ...(!!parentRow && { hiddenChild: getHiddenChildState(parentRow) })
+    ...(Array.isArray(row._children) && { expanded: !!row._attributes!.expanded }),
+    ...(!!parentRow && { hiddenChild: isHiddenRow(parentRow) })
   });
 
   return rawRow;

--- a/src/helper/tree.ts
+++ b/src/helper/tree.ts
@@ -63,7 +63,13 @@ export function isLeaf(row: Row) {
 export function isExpanded(row: Row) {
   const { tree } = row._attributes;
 
-  return !!tree && tree.expanded;
+  return !!(tree && tree.expanded);
+}
+
+function isHidden(row: Row) {
+  const { tree } = row._attributes;
+
+  return !!(tree && tree.hidden);
 }
 
 export function isRootChildRow(row: Row) {
@@ -84,18 +90,6 @@ export function getDepth(rawData: Row[], row?: Row) {
   return depth;
 }
 
-export function isHiddenRow(row: Row) {
-  if (row) {
-    const { tree } = row._attributes;
-    const collapsed = !isExpanded(row);
-    const hiddenChild = !!(tree && tree.hiddenChild);
-
-    return collapsed || hiddenChild;
-  }
-
-  return false;
-}
-
 function createTreeRawRow(
   row: OptRow,
   defaultValues: ColumnDefaultValues,
@@ -107,7 +101,8 @@ function createTreeRawRow(
   const { rowKey } = rawRow;
   const defaultAttributes = {
     parentRowKey: parentRow ? parentRow.rowKey : null,
-    childRowKeys: []
+    childRowKeys: [],
+    hidden: parentRow ? !isExpanded(parentRow) || isHidden(parentRow) : false
   };
 
   if (parentRow) {
@@ -120,8 +115,7 @@ function createTreeRawRow(
 
   rawRow._attributes.tree = observable({
     ...defaultAttributes,
-    ...(Array.isArray(row._children) && { expanded: !!row._attributes!.expanded }),
-    ...(!!parentRow && { hiddenChild: isHiddenRow(parentRow) })
+    ...(Array.isArray(row._children) && { expanded: !!row._attributes!.expanded })
   });
 
   return rawRow;

--- a/src/helper/tree.ts
+++ b/src/helper/tree.ts
@@ -142,7 +142,7 @@ export function flattenTreeData(
     flattenedRows.push(rawRow);
 
     if (Array.isArray(row._children)) {
-      if (row._children.length > 0) {
+      if (row._children.length) {
         flattenedRows.push(...flattenTreeData(row._children, defaultValues, rawRow, keyColumnName));
       }
       delete rawRow._children;

--- a/src/helper/tree.ts
+++ b/src/helper/tree.ts
@@ -57,7 +57,7 @@ export function getChildRowKeys(row: Row) {
 export function isLeaf(row: Row) {
   const { tree } = row._attributes;
 
-  return !!tree && !tree.childRowKeys.length;
+  return !!tree && !tree.childRowKeys.length && isUndefined(tree.expanded);
 }
 
 export function isExpanded(row: Row) {
@@ -76,12 +76,6 @@ export function getDepth(rawData: Row[], row: Row) {
   } while (parentRow);
 
   return depth;
-}
-
-function hasChildrenState(row: OptRow) {
-  const { _children } = row;
-
-  return Array.isArray(_children) && _children.length > 0;
 }
 
 function getExpandedState(row: OptRow) {
@@ -130,7 +124,7 @@ function createTreeRawRow(
 
   rawRow._attributes.tree = observable({
     ...defaultAttributes,
-    ...(hasChildrenState(row) && { expanded: getExpandedState(row) }),
+    ...(Array.isArray(row._children) && { expanded: getExpandedState(row) }),
     ...(!!parentRow && { hiddenChild: getHiddenChildState(parentRow) })
   });
 
@@ -151,10 +145,10 @@ export function flattenTreeData(
 
     flattenedRows.push(rawRow);
 
-    if (hasChildrenState(row)) {
-      flattenedRows.push(
-        ...flattenTreeData(row._children || [], defaultValues, rawRow, keyColumnName)
-      );
+    if (Array.isArray(row._children)) {
+      if (row._children.length > 0) {
+        flattenedRows.push(...flattenTreeData(row._children, defaultValues, rawRow, keyColumnName));
+      }
       delete rawRow._children;
     }
   });

--- a/src/store/rowCoords.ts
+++ b/src/store/rowCoords.ts
@@ -9,7 +9,7 @@ interface RowCoordsOption {
 
 export function getRowHeight(row: Row, defaultRowHeight: number) {
   const { height, tree } = row._attributes;
-  const rowHeight = tree && tree.hiddenChild ? 0 : height;
+  const rowHeight = tree && tree.hidden ? 0 : height;
 
   return isNumber(rowHeight) ? rowHeight : defaultRowHeight;
 }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -132,7 +132,7 @@ export interface TreeRowInfo {
   parentRowKey: RowKey | null;
   childRowKeys: RowKey[];
   expanded?: boolean;
-  hiddenChild?: boolean;
+  hidden: boolean;
 }
 
 export interface TreeCellInfo {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

1. Add dynamic loading data.
```js
const treeData = [
  {
    name: 'c1',
    _children: [] // Set to empty array then row has toggle button 
  }
]
```
2. Fix that fire `expand` or `collapse` event.
  * `expand` or `collapse` event is not fired when calling `expandAll` or `collapseAll`.
  * `expand` or `collapse` event is not fired every expanded or collpased row.
```js
grid.on('expand', (ev) => {
  // ...
});

grid.expand();
grid.expandAll();
```
3. Bind `dataSoucre` on tree data
```js
const instance = new Grid({
  // ...
  treeColumnOptions: {
    name: 'c1'
  },
  data: {
    api: {
      readData: { url: '/api/readData', method: 'GET' }
    }
  }
});

grid.on('expand', (ev) => {
  const { rowKey: parentRowKey } = ev;
  const childRowKeys = grid.getChildRows(rowKey);

  if (!childRowKeys.length) {
    grid.readData(1, { parentRowKey });
    // grid.readTreeData(parentRowKey, data);
  }
});
```

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
