### PR TITLE
fix: Remove 'el' variable reference from EditingLayerInnerComp class (#652)

### DIFF
--- a/src/view/editingLayerInner.tsx
+++ b/src/view/editingLayerInner.tsx
@@ -81,7 +81,7 @@ export class EditingLayerInnerComp extends Component<Props> {
       this.contentEl.appendChild(editorEl);
       this.editor = cellEditor;
 
-      const editorWidth = (this.editor.el as HTMLElement).getBoundingClientRect().width;
+      const editorWidth = editorEl.getBoundingClientRect().width;
 
       if (editorWidth > width!) {
         const CELL_PADDING_WIDTH = 10;


### PR DESCRIPTION
fix: Remove 'el' variable reference from EditingLayerInnerComp class (#652)

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
Remove 'el' variable reference from EditingLayerInnerComp class
Change to using 'editorEl' variable


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
