### PR TITLE
fix: Manually change 'checkedAllRows' in observable (#662)

### DIFF
--- a/cypress/integration/rowHeaders.spec.ts
+++ b/cypress/integration/rowHeaders.spec.ts
@@ -79,17 +79,17 @@ describe('row header API', () => {
   });
 
   it('checkAll, uncheckAll (Dynamic rendering)', () => {
-    const localData = [];
-    for (let i = 0; i < 1000; i ++) {
-      localData.push({
+    const gridData = [];
+    for (let i = 0; i < 1000; i += 1) {
+      gridData.push({
         id: i,
-        name: 'name'+i,
-        artist: 'artist'+i,
-        type: 'type'+i
+        name: `name${i}`,
+        artist: `artist${i}`,
+        type: `type${i}`
       });
     }
     cy.gridInstance().invoke('setBodyHeight', 300);
-    cy.gridInstance().invoke('resetData', localData);
+    cy.gridInstance().invoke('resetData', gridData);
     cy.gridInstance().invoke('checkAll');
 
     cy.get('input').should($el => {

--- a/cypress/integration/rowHeaders.spec.ts
+++ b/cypress/integration/rowHeaders.spec.ts
@@ -77,4 +77,33 @@ describe('row header API', () => {
         ).to.be.true;
       });
   });
+
+  it('checkAll, uncheckAll (Dynamic rendering)', () => {
+    const localData = [];
+    for (let i = 0; i < 1000; i ++) {
+      localData.push({
+        id: i,
+        name: 'name'+i,
+        artist: 'artist'+i,
+        type: 'type'+i
+      });
+    }
+    cy.gridInstance().invoke('setBodyHeight', 300);
+    cy.gridInstance().invoke('resetData', localData);
+    cy.gridInstance().invoke('checkAll');
+
+    cy.get('input').should($el => {
+      $el.each((_, elem) => {
+        expect(elem.checked).to.be.true;
+      });
+    });
+
+    cy.gridInstance().invoke('uncheckAll');
+
+    cy.get('input').should($el => {
+      $el.each((_, elem) => {
+        expect(elem.checked).to.be.false;
+      });
+    });
+  });
 });

--- a/src/dispatch/data.ts
+++ b/src/dispatch/data.ts
@@ -147,8 +147,9 @@ export function setColumnValues(
 
 export function check(store: Store, rowKey: RowKey) {
   const { allColumnMap, treeColumnName = '' } = store.column;
-  const { rawData } = store.data;
-  const eventBus = getEventBus(store.id);
+  const { data, id } = store;
+  const { rawData } = data;
+  const eventBus = getEventBus(id);
   const gridEvent = new GridEvent({ rowKey });
 
   /**
@@ -160,7 +161,7 @@ export function check(store: Store, rowKey: RowKey) {
   eventBus.trigger('check', gridEvent);
 
   setRowAttribute(store, rowKey, 'checked', true);
-  store.data.checkedAllRows = !rawData.some(row => !row._attributes.checked);
+  data.checkedAllRows = !rawData.some(row => !row._attributes.checked);
 
   if (allColumnMap[treeColumnName]) {
     changeTreeRowsCheckedState(store, rowKey, true);
@@ -168,8 +169,9 @@ export function check(store: Store, rowKey: RowKey) {
 }
 
 export function uncheck(store: Store, rowKey: RowKey) {
-  const { allColumnMap, treeColumnName = '' } = store.column;
-  const eventBus = getEventBus(store.id);
+  const { data, id, column } = store;
+  const { allColumnMap, treeColumnName = '' } = column;
+  const eventBus = getEventBus(id);
   const gridEvent = new GridEvent({ rowKey });
 
   /**
@@ -181,7 +183,7 @@ export function uncheck(store: Store, rowKey: RowKey) {
   eventBus.trigger('uncheck', gridEvent);
 
   setRowAttribute(store, rowKey, 'checked', false);
-  store.data.checkedAllRows = false;
+  data.checkedAllRows = false;
 
   if (allColumnMap[treeColumnName]) {
     changeTreeRowsCheckedState(store, rowKey, false);
@@ -189,9 +191,10 @@ export function uncheck(store: Store, rowKey: RowKey) {
 }
 
 export function checkAll(store: Store) {
+  const { data, id } = store;
   setAllRowAttribute(store, 'checked', true);
-  store.data.checkedAllRows = true;
-  const eventBus = getEventBus(store.id);
+  data.checkedAllRows = true;
+  const eventBus = getEventBus(id);
   const gridEvent = new GridEvent();
 
   /**
@@ -203,9 +206,10 @@ export function checkAll(store: Store) {
 }
 
 export function uncheckAll(store: Store) {
+  const { data, id } = store;
   setAllRowAttribute(store, 'checked', false);
-  store.data.checkedAllRows = false;
-  const eventBus = getEventBus(store.id);
+  data.checkedAllRows = false;
+  const eventBus = getEventBus(id);
   const gridEvent = new GridEvent();
 
   /**

--- a/src/dispatch/data.ts
+++ b/src/dispatch/data.ts
@@ -147,6 +147,7 @@ export function setColumnValues(
 
 export function check(store: Store, rowKey: RowKey) {
   const { allColumnMap, treeColumnName = '' } = store.column;
+  const { rawData } = store.data;
   const eventBus = getEventBus(store.id);
   const gridEvent = new GridEvent({ rowKey });
 
@@ -159,6 +160,7 @@ export function check(store: Store, rowKey: RowKey) {
   eventBus.trigger('check', gridEvent);
 
   setRowAttribute(store, rowKey, 'checked', true);
+  store.data.checkedAllRows = !rawData.some(row => !row._attributes.checked);
 
   if (allColumnMap[treeColumnName]) {
     changeTreeRowsCheckedState(store, rowKey, true);
@@ -179,6 +181,7 @@ export function uncheck(store: Store, rowKey: RowKey) {
   eventBus.trigger('uncheck', gridEvent);
 
   setRowAttribute(store, rowKey, 'checked', false);
+  store.data.checkedAllRows = false;
 
   if (allColumnMap[treeColumnName]) {
     changeTreeRowsCheckedState(store, rowKey, false);
@@ -187,6 +190,7 @@ export function uncheck(store: Store, rowKey: RowKey) {
 
 export function checkAll(store: Store) {
   setAllRowAttribute(store, 'checked', true);
+  store.data.checkedAllRows = true;
   const eventBus = getEventBus(store.id);
   const gridEvent = new GridEvent();
 
@@ -200,6 +204,7 @@ export function checkAll(store: Store) {
 
 export function uncheckAll(store: Store) {
   setAllRowAttribute(store, 'checked', false);
+  store.data.checkedAllRows = false;
   const eventBus = getEventBus(store.id);
   const gridEvent = new GridEvent();
 

--- a/src/store/data.ts
+++ b/src/store/data.ts
@@ -454,6 +454,7 @@ export function create({
     viewData,
     sortOptions,
     pageOptions,
+    checkedAllRows: !rawData.some(row => !row._attributes.checked),
 
     get pageRowRange() {
       let start = 0;
@@ -467,12 +468,6 @@ export function create({
       }
 
       return [start, end] as Range;
-    },
-
-    get checkedAllRows() {
-      const allRawData = this.rawData;
-      const checkedRows = allRawData.filter(row => row._attributes.checked);
-      return checkedRows.length === allRawData.length;
     }
   });
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
`checkedAllRows` previously managed as an observable
There was only a getter that checked and returned a check in row.
However, the Observer does not work properly when in dynamic rendering.
Therefore, changed the `checkedAllRows` variable to be managed manually.
Inside the checkAll, uncheckAll, check, uncheck methods
Added code to manually change the value of `checkedAllRows`.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
