### PR TITLE
fix: changed the paging count properly when calls setPerPage API (#667)

### DIFF
--- a/cypress/helper/runMockServer.ts
+++ b/cypress/helper/runMockServer.ts
@@ -69,6 +69,21 @@ export function runMockServer() {
   }).as('readDescData');
 
   cy.route({
+    method: 'GET',
+    url: 'api/read?perPage=5&page=1',
+    response: {
+      result: true,
+      data: {
+        contents: data.slice(0, 5),
+        pagination: {
+          page: 1,
+          totalCount: 20
+        }
+      }
+    }
+  }).as('perPage5');
+
+  cy.route({
     method: 'POST',
     url: '/api/create',
     response: successResponse

--- a/cypress/integration/dataSource.spec.ts
+++ b/cypress/integration/dataSource.spec.ts
@@ -76,14 +76,16 @@ function assertSortedData(columnName: string, ascending = true) {
   });
 }
 
-function assertPagingData(columnName: string, page = 1) {
-  const pagingData = page === 1 ? sampleData.slice(0, 10) : sampleData.slice(10);
+function assertPagingData(columnName: string, page = 1, perPage = 10) {
+  const pagingData = page === 1 ? sampleData.slice(0, perPage) : sampleData.slice(perPage);
   const testData = (pagingData as Dictionary<any>[]).map(sample => String(sample[columnName]));
 
   cy.get(`td[${dataAttr.COLUMN_NAME}=${columnName}]`).should($el => {
-    $el.each((index, elem) => {
-      expect(elem.textContent).to.eql(testData[index]);
-    });
+    $el
+      .filter(index => index < perPage)
+      .each((index, elem) => {
+        expect(elem.textContent).to.eql(testData[index]);
+      });
   });
 }
 
@@ -223,4 +225,18 @@ it('restore()', () => {
 
   assertPagingData('id', 1);
   assertModifiedRowsLength('deletedRows', 0);
+});
+
+it('setPerPage()', () => {
+  cy.wait('@readPage1');
+
+  cy.get(`.tui-page-btn`).should('have.length', 6);
+  assertPagingData('id', 1, 10);
+
+  cy.gridInstance().invoke('setPerPage', 5);
+
+  cy.wait('@perPage5');
+
+  cy.get(`.tui-page-btn`).should('have.length', 8);
+  assertPagingData('id', 1, 5);
 });

--- a/cypress/integration/dataSource.spec.ts
+++ b/cypress/integration/dataSource.spec.ts
@@ -230,13 +230,13 @@ it('restore()', () => {
 it('setPerPage()', () => {
   cy.wait('@readPage1');
 
-  cy.get(`.tui-page-btn`).should('have.length', 6);
+  cy.get('.tui-page-btn').should('have.length', 6);
   assertPagingData('id', 1, 10);
 
   cy.gridInstance().invoke('setPerPage', 5);
 
   cy.wait('@perPage5');
 
-  cy.get(`.tui-page-btn`).should('have.length', 8);
+  cy.get('.tui-page-btn').should('have.length', 8);
   assertPagingData('id', 1, 5);
 });

--- a/docs/ko/pagination.md
+++ b/docs/ko/pagination.md
@@ -64,7 +64,7 @@ const grid = new Grid({
 | 이름 | 설명 |
 | --- | --- |
 | `getPagination` | Grid에서 사용하고 있는 `tui-pagination`의 인스턴스를 반환한다. <br>(*페이지네이션 기능을 사용하지 않는 경우는 `null`을 반환한다.*) | 
-| `setPerPage` | 한 페이지에 보여줄 데이터 수를 변경한다. <br>(*현재 클라이언트 페이지네이션에서 해당 API는 지원되지 않는 상태이며, 이후 추가 지원될 계획이다.*) | 
+| `setPerPage` | 한 페이지에 보여줄 데이터 수를 변경한다. | 
 
 ```js
 const pagination = grid.getPagination();

--- a/src/dataSource/serverSideDataProvider.ts
+++ b/src/dataSource/serverSideDataProvider.ts
@@ -84,7 +84,7 @@ class ServerSideDataProvider implements DataProvider {
       return;
     }
     this.dispatch('resetData', data.contents);
-    this.dispatch('setPagination', data.pagination);
+    this.dispatch('setPagination', { ...data.pagination, perPage: this.lastRequiredData.perPage });
   };
 
   private handleSuccessReadTreeData = (response: Response) => {

--- a/src/dispatch/data.ts
+++ b/src/dispatch/data.ts
@@ -512,8 +512,7 @@ export function refreshRowHeight({ data, rowCoords }: Store, rowIndex: number, r
 }
 
 export function setPagination({ data }: Store, pageOptions: PageOptions) {
-  const { perPage } = data.pageOptions;
-  data.pageOptions = { ...pageOptions, perPage } as Required<PageOptions>;
+  data.pageOptions = pageOptions as Required<PageOptions>;
 }
 
 export function movePage({ data, rowCoords, dimension }: Store, page: number) {

--- a/src/grid.tsx
+++ b/src/grid.tsx
@@ -1154,8 +1154,12 @@ export default class Grid {
   public setPerPage(perPage: number) {
     const pagination = this.getPagination();
     if (pagination) {
-      pagination.setItemsPerPage(perPage);
-      this.readData(1, { perPage });
+      const { pageOptions } = this.store.data;
+      if (pageOptions.useClient) {
+        this.dispatch('setPagination', { ...pageOptions, perPage, page: 1 });
+      } else {
+        this.readData(1, { perPage });
+      }
     }
   }
 

--- a/src/view/pagination.tsx
+++ b/src/view/pagination.tsx
@@ -42,13 +42,18 @@ class PaginationComp extends Component<Props> {
     const { pageOptions } = nextProps;
     const { totalCount, page, perPage } = pageOptions;
 
-    if (isNumber(perPage) && this.props.pageOptions.perPage !== perPage) {
-      this.tuiPagination.setItemsPerPage(perPage);
+    if (!isNumber(totalCount) || !isNumber(page) || !isNumber(perPage)) {
+      return;
     }
-    if (isNumber(totalCount) && this.props.pageOptions.totalCount !== totalCount) {
+
+    if (
+      this.props.pageOptions.perPage !== perPage ||
+      this.props.pageOptions.totalCount !== totalCount
+    ) {
+      this.tuiPagination.setItemsPerPage(perPage);
       this.tuiPagination.reset(totalCount);
     }
-    if (isNumber(page) && this.tuiPagination.getCurrentPage() !== page) {
+    if (this.tuiPagination.getCurrentPage() !== page) {
       this.removeEventListener();
       this.tuiPagination.movePageTo(page);
       this.addEventListener();


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* changed the paging count properly when calls setPerPage API.
* setPerPage API is operated in client pagination.
* related issue(#667)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
