### PR TITLE
fix: makes synchronous rendering on start or finish editing(#682, #686)

### DIFF
--- a/cypress/integration/editor.spec.ts
+++ b/cypress/integration/editor.spec.ts
@@ -250,3 +250,31 @@ it('cannot save the value and finish the editing on hidden cell', () => {
 
   cy.get(`.${cls('layer-editing')}`).should('not.be.visible');
 });
+
+it('should renering of the editing cell is syncronous', () => {
+  const data = [{ name: 'Lee', age: 20 }, { name: 'Han', age: 28 }, { name: 'Ryu', age: 22 }];
+  const columns = [{ name: 'name', editor: 'text' }, { name: 'age', editor: 'text' }];
+  const stub = cy.stub();
+
+  cy.createGrid({ data, columns });
+
+  cy.gridInstance().invoke('on', 'editingFinish', stub);
+
+  cy.gridInstance().invoke('startEditing', 0, 'name');
+  cy.get(`.${cls('content-text')}`).type('Kim');
+  cy.gridInstance().invoke('finishEditing', 0, 'name');
+
+  cy.gridInstance()
+    .invoke('getValue', 0, 'name')
+    .should('eq', 'Kim');
+
+  cy.gridInstance().invoke('startEditing', 1, 'name');
+  cy.get(`.${cls('content-text')}`)
+    .invoke('val')
+    .should('eq', 'Han')
+    .and(() => {
+      expect(stub).to.be.calledOnce;
+      expect(isSubsetOf({ rowKey: 0, columnName: 'name', value: 'Kim' }, stub.args[0][0])).to.be
+        .true;
+    });
+});

--- a/cypress/integration/eventBus.spec.ts
+++ b/cypress/integration/eventBus.spec.ts
@@ -328,6 +328,7 @@ it('editingFinish', () => {
 
   cy.gridInstance().invoke('on', 'editingFinish', callback);
 
+  cy.gridInstance().invoke('startEditing', 0, 'name');
   cy.gridInstance()
     .invoke('finishEditing', 0, 'name', 'Ryu')
     .should(() => {

--- a/cypress/integration/filter.spec.ts
+++ b/cypress/integration/filter.spec.ts
@@ -418,7 +418,7 @@ describe('date', () => {
       .focus()
       .click();
     // 2019.09.18 timestamp
-    cy.get(`[data-timestamp=1568732400000]`).click();
+    cy.get(`.${cls('datepicker-input')}`).type('2019-09-18{Enter}');
     equalColumnData('date', '2019.09.18');
     compareColumnCellLength(3);
   });
@@ -430,7 +430,7 @@ describe('date', () => {
       .focus()
       .click();
     // 2019.09.18 timestamp
-    cy.get(`[data-timestamp=1568732400000]`).click();
+    cy.get(`.${cls('datepicker-input')}`).type('2019-09-18{Enter}');
     notEqualColumnData('date', '2019.09.18');
     compareColumnCellLength(6);
   });
@@ -442,7 +442,7 @@ describe('date', () => {
       .focus()
       .click();
     // 2019.09.18 timestamp
-    cy.get(`[data-timestamp=1568732400000]`).click();
+    cy.get(`.${cls('datepicker-input')}`).type('2019-09-18{Enter}');
     cy.get(`[data-column-name=date]td.${cls('cell')}`).should($el => {
       $el.each((index, elem) => {
         expect(getUnixTime(elem.textContent) > getUnixTime('2019/09/18')).to.be.true;
@@ -458,7 +458,7 @@ describe('date', () => {
       .focus()
       .click();
     // 2019.09.18 timestamp
-    cy.get(`[data-timestamp=1568732400000]`).click();
+    cy.get(`.${cls('datepicker-input')}`).type('2019-09-18{Enter}');
     cy.get(`[data-column-name=date]td.${cls('cell')}`).should($el => {
       $el.each((index, elem) => {
         expect(getUnixTime(elem.textContent) >= getUnixTime('2019/09/18')).to.be.true;
@@ -474,7 +474,7 @@ describe('date', () => {
       .focus()
       .click();
     // 2019.09.18 timestamp
-    cy.get(`[data-timestamp=1568732400000]`).click();
+    cy.get(`.${cls('datepicker-input')}`).type('2019-09-18{Enter}');
     cy.get(`[data-column-name=date]td.${cls('cell')}`).should($el => {
       $el.each((index, elem) => {
         expect(getUnixTime(elem.textContent) < getUnixTime('2019/09/18')).to.be.true;
@@ -490,7 +490,7 @@ describe('date', () => {
       .focus()
       .click();
     // 2019.09.18 timestamp
-    cy.get(`[data-timestamp=1568732400000]`).click();
+    cy.get(`.${cls('datepicker-input')}`).type('2019-09-18{Enter}');
     cy.get(`[data-column-name=date]td.${cls('cell')}`).should($el => {
       $el.each((index, elem) => {
         expect(getUnixTime(elem.textContent) <= getUnixTime('2019/09/18')).to.be.true;

--- a/cypress/integration/lazyObservable.spec.ts
+++ b/cypress/integration/lazyObservable.spec.ts
@@ -53,7 +53,6 @@ describe('API test on lazy observable data', () => {
   });
 
   it('startEditing api', () => {
-    cy.gridInstance().invoke('focus', 18, 'name');
     cy.gridInstance().invoke('startEditing', 18, 'name', 'Lee');
     cy.get(`.${cls('content-text')}`).type('Lee{enter}');
 
@@ -67,6 +66,7 @@ describe('API test on lazy observable data', () => {
   });
 
   it('finishEditing api', () => {
+    cy.gridInstance().invoke('startEditing', 18, 'name');
     cy.gridInstance().invoke('finishEditing', 18, 'name', 'Kim');
     cy.gridInstance()
       .invoke('getValue', 18, 'name')
@@ -117,6 +117,7 @@ describe('API test on lazy observable data', () => {
   });
 
   it('findRow api', () => {
+    cy.gridInstance().invoke('startEditing', 18, 'name');
     cy.gridInstance().invoke('finishEditing', 18, 'name', 'Lee');
     cy.gridInstance()
       .invoke('findRows', { name: 'Lee' })

--- a/cypress/integration/relation.spec.ts
+++ b/cypress/integration/relation.spec.ts
@@ -2,7 +2,9 @@ import { cls } from '../../src/helper/dom';
 import { data, columns } from '../../samples/relations';
 
 function assertRelation() {
+  cy.gridInstance().invoke('startEditing', 0, 'category1');
   cy.gridInstance().invoke('finishEditing', 0, 'category1', '01');
+  cy.gridInstance().invoke('startEditing', 0, 'category2');
   cy.gridInstance().invoke('finishEditing', 0, 'category2', '01_01');
 
   cy.getCell(0, 'category2').contains('Balad/Dance/Pop');
@@ -35,6 +37,7 @@ it('should change state by relations', () => {
 });
 
 it('change cell disabled state', () => {
+  cy.gridInstance().invoke('startEditing', 1, 'category1');
   cy.gridInstance().invoke('finishEditing', 1, 'category1', '');
 
   cy.gridInstance().invoke('startEditing', 1, 'category2');
@@ -53,6 +56,7 @@ it('change cell editable state', () => {
   });
   cy.createGrid({ data, columns });
 
+  cy.gridInstance().invoke('startEditing', 1, 'category1');
   cy.gridInstance().invoke('finishEditing', 1, 'category1', '');
 
   cy.gridInstance().invoke('startEditing', 1, 'category2');

--- a/src/dispatch/filter.ts
+++ b/src/dispatch/filter.ts
@@ -1,6 +1,6 @@
 import { ActiveColumnAddress, FilterState, Store } from '../store/types';
 import { notify } from '../helper/observable';
-import { findProp, findPropIndex, mapProp, uniq } from '../helper/common';
+import { findProp, findPropIndex, mapProp, uniq, isNull } from '../helper/common';
 import { composeConditionFn, getFilterConditionFn } from '../helper/filter';
 import { FilterOpt, OperatorType, FilterOptionType } from '../types';
 import { getRowHeight } from '../store/rowCoords';
@@ -99,7 +99,13 @@ export function setActiveColumnAddress(store: Store, address: ActiveColumnAddres
 function resetActiveColumnAddress(store: Store) {
   const { data, filterLayerState } = store;
   const { rawData } = data;
-  const { type, state, columnName } = filterLayerState.activeFilterState!;
+  const { activeFilterState } = filterLayerState;
+
+  if (isNull(activeFilterState)) {
+    return;
+  }
+
+  const { type, state, columnName } = activeFilterState!;
   if (type !== 'select' && !state.length) {
     unfilter(store, columnName);
   } else if (type === 'select') {

--- a/src/dispatch/filter.ts
+++ b/src/dispatch/filter.ts
@@ -105,7 +105,7 @@ function resetActiveColumnAddress(store: Store) {
     return;
   }
 
-  const { type, state, columnName } = activeFilterState!;
+  const { type, state, columnName } = activeFilterState;
   if (type !== 'select' && !state.length) {
     unfilter(store, columnName);
   } else if (type === 'select') {

--- a/src/dispatch/focus.ts
+++ b/src/dispatch/focus.ts
@@ -44,6 +44,7 @@ export function startEditing(store: Store, rowKey: RowKey, columnName: string) {
 
   if (!gridEvent.isStopped()) {
     occurSyncRendering(() => {
+      focus.forcedDestroyEditing = false;
       focus.navigating = false;
       focus.editingAddress = { rowKey, columnName };
     });
@@ -74,7 +75,6 @@ export function finishEditing(
   if (!gridEvent.isStopped()) {
     if (isEditingCell(focus, rowKey, columnName)) {
       occurSyncRendering(() => {
-        focus.forcedDestroyEditing = false;
         focus.editingAddress = null;
         focus.navigating = true;
       });

--- a/src/editor/text.ts
+++ b/src/editor/text.ts
@@ -1,5 +1,6 @@
 import { CellEditor, CellEditorProps } from './types';
 import { cls } from '../helper/dom';
+import { isUndefined, isNull } from '../helper/common';
 
 interface Options {
   type: 'text' | 'password';
@@ -14,7 +15,7 @@ export class TextEditor implements CellEditor {
 
     el.className = cls('content-text');
     el.type = options.type;
-    el.value = String(props.value || '');
+    el.value = String(isUndefined(props.value) || isNull(props.value) ? '' : props.value);
 
     this.el = el;
   }

--- a/src/grid.tsx
+++ b/src/grid.tsx
@@ -642,7 +642,7 @@ export default class Grid {
    * @param {string} columnName - The name of the column
    * @param {string} value - The value of editing result
    */
-  public finishEditing(rowKey: RowKey, columnName: string, value: string) {
+  public finishEditing(rowKey: RowKey, columnName: string, value?: string) {
     // @TODO: change grid API name(finishEditing -> saveAndFinishEditing)
     this.dispatch('saveAndFinishEditing', rowKey, columnName, value);
   }

--- a/src/helper/render.ts
+++ b/src/helper/render.ts
@@ -1,0 +1,7 @@
+import { options } from 'preact';
+
+export function occurSyncRendering(fn: Function) {
+  options.debounceRendering = f => f();
+  fn();
+  delete options.debounceRendering;
+}

--- a/src/helper/render.ts
+++ b/src/helper/render.ts
@@ -1,6 +1,6 @@
 import { options } from 'preact';
 
-export function occurSyncRendering(fn: Function) {
+export function forceSyncRendering(fn: Function) {
   options.debounceRendering = f => f();
   fn();
   delete options.debounceRendering;

--- a/src/query/focus.ts
+++ b/src/query/focus.ts
@@ -3,3 +3,11 @@ import { RowKey, Focus } from '../store/types';
 export function isFocusedCell(focus: Focus, rowKey: RowKey | null, columnName: string | null) {
   return rowKey === focus.rowKey && columnName === focus.columnName;
 }
+
+export function isEditingCell(focus: Focus, rowKey: RowKey, columnName: string) {
+  const { editingAddress } = focus;
+
+  return (
+    editingAddress && editingAddress.rowKey === rowKey && editingAddress.columnName === columnName
+  );
+}

--- a/src/store/focus.ts
+++ b/src/store/focus.ts
@@ -29,6 +29,7 @@ export function create({
     editingAddress: null,
     editingEvent,
     navigating: false,
+    forcedDestroyEditing: false,
 
     get side(this: Focus) {
       if (this.columnName === null) {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -400,6 +400,7 @@ export interface Focus {
   columnName: string | null;
   prevRowKey: RowKey | null;
   prevColumnName: string | null;
+  forcedDestroyEditing: boolean;
   readonly side: Side | null;
   readonly columnIndex: number | null;
   readonly totalColumnIndex: number | null;

--- a/src/view/editingLayerInner.tsx
+++ b/src/view/editingLayerInner.tsx
@@ -24,6 +24,7 @@ interface StoreProps {
   filter?: Filter;
   focusedColumnName: string | null;
   focusedRowKey: RowKey | null;
+  forcedDestroyEditing: boolean;
 }
 
 interface OwnProps {
@@ -97,7 +98,9 @@ export class EditingLayerInnerComp extends Component<Props> {
   }
 
   public componentWillUnmount() {
-    this.finishEditing(false);
+    if (this.props.forcedDestroyEditing) {
+      this.finishEditing(true);
+    }
     if (this.editor && this.editor.beforeDestroy) {
       this.editor.beforeDestroy();
     }
@@ -135,13 +138,20 @@ export class EditingLayerInnerComp extends Component<Props> {
 
 export const EditingLayerInner = connect<StoreProps, OwnProps>((store, { rowKey, columnName }) => {
   const { data, column, id, focus, viewport, dimension, columnCoords } = store;
-  const { cellPosRect, side, columnName: focusedColumnName, rowKey: focusedRowKey } = focus;
+  const {
+    cellPosRect,
+    side,
+    columnName: focusedColumnName,
+    rowKey: focusedRowKey,
+    forcedDestroyEditing
+  } = focus;
   const { filteredViewData, sortState } = data;
   const state = {
     grid: getInstance(id),
     sortState,
     focusedColumnName,
-    focusedRowKey
+    focusedRowKey,
+    forcedDestroyEditing
   };
 
   if (isNull(cellPosRect)) {

--- a/src/view/editingLayerInner.tsx
+++ b/src/view/editingLayerInner.tsx
@@ -59,6 +59,7 @@ type Props = StoreProps & OwnProps & DispatchProps;
  * - Step 5: the layer is unmounted.
  *
  * 4. In case of controlling by finishEditing grid API with 'undefined' value parameter.
+ *    (ex. grid.finishEditing(0, 'columnName');)
  * - Step 1: dispath the saveAndFinishEditing.
  * - Step 2: editingAdress will be 'null'.
  * - Step 3: call the componentWillUnmount lifecycle method.

--- a/src/view/editingLayerInner.tsx
+++ b/src/view/editingLayerInner.tsx
@@ -34,6 +34,38 @@ interface OwnProps {
 
 type Props = StoreProps & OwnProps & DispatchProps;
 
+/**
+ * Process of unmounting the Editing layer
+ * 1. In case of controlling by the keyMap
+ * - Step 1: call the handleKeyDown method.
+ * - Step 2: dispath the finishEditing.
+ * - Step 3: occur the editingFinish event and editingAdress will be 'null'.
+ * - Step 4: call the componentWillUnmount lifecycle method.
+ * - Step 5: the layer is unmounted.
+ *
+ * 2. In case of controlling by clicking another cell
+ * - Step 1: call the componentWillReceiveProps lifecycle method.
+ * - Step 2: dispath the finishEditing.
+ * - Step 3: occur the editingFinish event and editingAdress will be 'null'.
+ * - Step 4: call the componentWillUnmount lifecycle method.
+ * - Step 5: the layer is unmounted.
+ *
+ * 3. In case of controlling by finishEditing grid API with value parameter.
+ *    (ex. grid.finishEditing(0, 'columnName', 'someValue');)
+ * - Step 1: dispath the saveAndFinishEditing.
+ * - Step 2: call the finishEditing function in dispatch/focus.ts
+ * - Step 3: occur the editingFinish event and editingAdress will be 'null'.
+ * - Step 4: call the componentWillUnmount lifecycle method.
+ * - Step 5: the layer is unmounted.
+ *
+ * 4. In case of controlling by finishEditing grid API with 'undefined' value parameter.
+ * - Step 1: dispath the saveAndFinishEditing.
+ * - Step 2: editingAdress will be 'null'.
+ * - Step 3: call the componentWillUnmount lifecycle method.
+ * - Step 4: dispath the finishEditing(due to forcedDestroyEditing prop is 'true').
+ * - Step 5: occur the editingFinish event(editingAddress is already 'null').
+ * - Step 6: the layer is unmounted.
+ */
 export class EditingLayerInnerComp extends Component<Props> {
   private editor?: CellEditor;
 

--- a/src/view/editingLayerInner.tsx
+++ b/src/view/editingLayerInner.tsx
@@ -89,18 +89,10 @@ export class EditingLayerInnerComp extends Component<Props> {
 
   private finishEditing(save: boolean) {
     if (this.editor) {
-      const { dispatch, rowKey, columnName, sortState, filter } = this.props;
+      const { dispatch, rowKey, columnName } = this.props;
       const value = this.editor.getValue();
       if (save) {
         dispatch('setValue', rowKey, columnName, value);
-        const sortIndex = findPropIndex('columnName', columnName, sortState.columns);
-        if (sortIndex !== -1) {
-          dispatch('sort', columnName, sortState.columns[sortIndex].ascending, true, false);
-        }
-        if (filter) {
-          const { conditionFn, state } = filter;
-          dispatch('filter', columnName, conditionFn!, state);
-        }
       }
       dispatch('finishEditing', rowKey, columnName, value);
     }

--- a/src/view/editingLayerInner.tsx
+++ b/src/view/editingLayerInner.tsx
@@ -46,7 +46,7 @@ type Props = StoreProps & OwnProps & DispatchProps;
  * 2. In case of controlling by clicking another cell
  * - Step 1: call the componentWillReceiveProps lifecycle method.
  * - Step 2: dispath the finishEditing.
- * - Step 3: occur the editingFinish event and editingAdress will be 'null'.
+ * - Step 3: occur the editingFinish event and editingAddress will be 'null'.
  * - Step 4: call the componentWillUnmount lifecycle method.
  * - Step 5: the layer is unmounted.
  *
@@ -54,14 +54,14 @@ type Props = StoreProps & OwnProps & DispatchProps;
  *    (ex. grid.finishEditing(0, 'columnName', 'someValue');)
  * - Step 1: dispath the saveAndFinishEditing.
  * - Step 2: call the finishEditing function in dispatch/focus.ts
- * - Step 3: occur the editingFinish event and editingAdress will be 'null'.
+ * - Step 3: occur the editingFinish event and editingAddress will be 'null'.
  * - Step 4: call the componentWillUnmount lifecycle method.
  * - Step 5: the layer is unmounted.
  *
  * 4. In case of controlling by finishEditing grid API with 'undefined' value parameter.
  *    (ex. grid.finishEditing(0, 'columnName');)
  * - Step 1: dispath the saveAndFinishEditing.
- * - Step 2: editingAdress will be 'null'.
+ * - Step 2: editingAddress will be 'null'.
  * - Step 3: call the componentWillUnmount lifecycle method.
  * - Step 4: dispath the finishEditing(due to forcedDestroyEditing prop is 'true').
  * - Step 5: occur the editingFinish event(editingAddress is already 'null').


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* made synchronous rendering on start or finish editing.
  *  DOM update of the editing cell has to be synchronous on calling startEditing, finishEditing API . Because the previous editing cell should be destroyed in case of calling finishEditing, startEditing API in a row.
* finishEditing API has been changed for `undefined` value parameter.
  * as the value parameter is `undefined`, the editor's value is saved the and finish editing.
* related issue(#682, #686)




---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
