### PR TITLE
fix: isOddRow bug fix in bodyDummyRow

### DIFF
--- a/src/view/bodyDummyRow.tsx
+++ b/src/view/bodyDummyRow.tsx
@@ -15,7 +15,7 @@ interface StoreProps {
 type Props = OwnProps & StoreProps;
 
 const BodyDummyRowComp = ({ columnNames, rowHeight, index }: Props) => {
-  const isOddRow = !!(index % 2);
+  const isOddRow = index % 2 === 0;
 
   return (
     <tr style={{ height: rowHeight }} class={cls([isOddRow, 'row-odd'], [!isOddRow, 'row-even'])}>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

Incorrectly calculating `isOddRow` variable in `bodyDummyRow.tsx`

**This is the result in storybook. (stories/dummyRows.stories.ts)**

**Before**
![image](https://user-images.githubusercontent.com/18422353/65945701-7eb7fa80-e46f-11e9-83a0-3216ab7170fe.png)

**After**
![image](https://user-images.githubusercontent.com/18422353/65945713-837cae80-e46f-11e9-98e6-488524d02d8e.png)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
