### PR TITLE
fix: bug that initialize filter date format

### DIFF
--- a/packages/toast-ui.grid/src/view/datePickerFilter.tsx
+++ b/packages/toast-ui.grid/src/view/datePickerFilter.tsx
@@ -52,18 +52,14 @@ class DatePickerFilterComp extends Component<Props> {
 
   private createDatePicker = () => {
     const { columnInfo, grid } = this.props;
-    const { options } = columnInfo.filter!;
+    const { options = {} } = columnInfo.filter!;
     const { usageStatistics } = grid;
     const { value } = this.getPreviousValue();
 
     let date;
-    let format = 'yyyy/MM/dd';
 
-    if (options) {
-      if (options.format) {
-        format = options.format;
-        delete options.format;
-      }
+    if (!options.format) {
+      options.format = 'yyyy/MM/dd';
     }
 
     if (isString(value) && value.length) {
@@ -75,7 +71,7 @@ class DatePickerFilterComp extends Component<Props> {
       type: 'date',
       input: {
         element: this.inputEl,
-        format
+        format: options.format
       },
       usageStatistics
     };


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
Changed filter date format.
But, datepicker close and reopen the format is initialized.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
