### PR TITLE
fix: focus the editing cell when datepicker layer is closed

### DIFF
--- a/packages/toast-ui.grid/cypress.json
+++ b/packages/toast-ui.grid/cypress.json
@@ -2,6 +2,6 @@
   "video": false,
   "viewportWidth": 800,
   "viewportHeight": 600,
-  "baseUrl": "http://localhost:8000",
+  "baseUrl": "http://localhost:8000/dist",
   "watchExtraFiles": ["dist"]
 }

--- a/packages/toast-ui.grid/cypress/integration/datePicker.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/datePicker.spec.ts
@@ -80,24 +80,20 @@ describe('default datePicker', () => {
   it('Cell value is applied correctly in the datePicker.', () => {
     cy.getCellContent(0, 'default').should('have.text', '2019-11-11');
 
-    cy.getCell(0, 'default')
-      .click()
-      .trigger('dblclick');
+    cy.gridInstance().invoke('startEditing', 0, 'default');
 
     cy.get('.tui-calendar-title').should('have.text', 'November 2019');
     cy.get('.tui-is-selected').should('have.text', '11');
   });
 
   it('select the date, the selected date is applied in the cell.', () => {
-    cy.getCell(0, 'default')
-      .click()
-      .trigger('dblclick');
+    cy.gridInstance().invoke('startEditing', 0, 'default');
 
     cy.get('.tui-calendar-date')
       .contains('14')
       .click();
-
     cy.getCell(0, 'timePicker').click();
+
     cy.getCellContent(0, 'default').should('have.text', '2019-11-14');
   });
 });
@@ -106,25 +102,21 @@ describe('timepicker', () => {
   it('use time picker to pick a time.', () => {
     cy.getCellContent(0, 'timePicker').should('have.text', '2019-11-11 11:11 AM');
 
-    cy.getCell(0, 'timePicker')
-      .click()
-      .trigger('dblclick');
+    cy.gridInstance().invoke('startEditing', 0, 'timePicker');
 
     cy.get('.tui-timepicker-hour')
       .get('select')
       .eq(2)
       .select('PM');
-
     cy.getCell(0, 'default').click();
+
     cy.getCellContent(0, 'timePicker').should('have.text', '2019-11-11 11:11 PM');
   });
 
   it('use time picker tab', () => {
     cy.getCellContent(0, 'timePickerWithTab').should('have.text', '2019-11-11 11:11 AM');
 
-    cy.getCell(0, 'timePickerWithTab')
-      .click()
-      .trigger('dblclick');
+    cy.gridInstance().invoke('startEditing', 0, 'timePickerWithTab');
     cy.get('.tui-datepicker-selector-button')
       .eq(1)
       .click();
@@ -142,9 +134,7 @@ describe('month picker', () => {
   it('You can choose the month, year excluding date.', () => {
     cy.getCellContent(0, 'monthPicker').should('have.text', '2019-11');
 
-    cy.getCell(0, 'monthPicker')
-      .click()
-      .trigger('dblclick');
+    cy.gridInstance().invoke('startEditing', 0, 'monthPicker');
 
     cy.get('.tui-calendar-month')
       .contains('Mar')
@@ -159,9 +149,7 @@ describe('year picker', () => {
   it('You can only choose the year.', () => {
     cy.getCellContent(0, 'yearPicker').should('have.text', '2019');
 
-    cy.getCell(0, 'yearPicker')
-      .click()
-      .trigger('dblclick');
+    cy.gridInstance().invoke('startEditing', 0, 'yearPicker');
     cy.get('.tui-calendar-year')
       .contains('2020')
       .click();
@@ -173,16 +161,13 @@ describe('year picker', () => {
 
 describe('show icon', () => {
   it("can't see the icon, when showIcon field false.", () => {
-    cy.getCell(0, 'default')
-      .click()
-      .trigger('dblclick');
+    cy.gridInstance().invoke('startEditing', 0, 'default');
 
     cy.get(`.${cls('date-icon')}`).should('visible');
     cy.get(`.${cls('layer-datepicker')} input`).should('have.class', cls('datepicker-input'));
 
-    cy.getCell(0, 'monthPicker')
-      .click()
-      .trigger('dblclick');
+    cy.gridInstance().invoke('finishEditing', 0, 'default');
+    cy.gridInstance().invoke('startEditing', 0, 'monthPicker');
 
     cy.get(`.${cls('date-icon')}`).should('not.visible');
     cy.get(`.${cls('layer-datepicker')} input`).should('have.class', cls('content-text'));
@@ -190,14 +175,11 @@ describe('show icon', () => {
 });
 
 it('focus the editing cell when datepicker layer is closed', () => {
-  cy.getCell(0, 'default')
-    .click()
-    .trigger('dblclick');
-
+  cy.gridInstance().invoke('startEditing', 0, 'default');
+  cy.focused().as('editingInput');
   cy.get('.tui-calendar-date')
     .contains('14')
     .click();
-  cy.focused().type('{Enter}');
 
-  cy.getCellContent(0, 'default').should('have.text', '2019-11-14');
+  cy.get('@editingInput').should('be.focused');
 });

--- a/packages/toast-ui.grid/cypress/integration/datePicker.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/datePicker.spec.ts
@@ -188,3 +188,16 @@ describe('show icon', () => {
     cy.get(`.${cls('layer-datepicker')} input`).should('have.class', cls('content-text'));
   });
 });
+
+it('focus the editing cell when datepicker layer is closed', () => {
+  cy.getCell(0, 'default')
+    .click()
+    .trigger('dblclick');
+
+  cy.get('.tui-calendar-date')
+    .contains('14')
+    .click();
+  cy.focused().type('{Enter}');
+
+  cy.getCellContent(0, 'default').should('have.text', '2019-11-14');
+});

--- a/packages/toast-ui.grid/cypress/plugins/index.js
+++ b/packages/toast-ui.grid/cypress/plugins/index.js
@@ -11,10 +11,11 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
+/* eslint-disable @typescript-eslint/no-var-requires */
 const wp = require('@cypress/webpack-preprocessor');
 const path = require('path');
 
-module.exports = (on, config) => {
+module.exports = on => {
   const options = {
     webpackOptions: {
       resolve: {

--- a/packages/toast-ui.grid/index.html
+++ b/packages/toast-ui.grid/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <link rel="stylesheet" type="text/css" href="https://uicdn.toast.com/tui.time-picker/v1.5.0/tui-time-picker.css" />
+    <link rel="stylesheet" type="text/css" href="https://uicdn.toast.com/tui.date-picker/v3.2.1/tui-date-picker.css" />
+    <link rel="stylesheet" type="text/css" href="https://uicdn.toast.com/tui.pagination/v3.3.0/tui-pagination.css" />
+  </head>
+  <body>
+  </body>
+</html>

--- a/packages/toast-ui.grid/src/css/grid.css
+++ b/packages/toast-ui.grid/src/css/grid.css
@@ -196,6 +196,7 @@
   filter: alpha(opacity=10);
 }
 .tui-grid-layer-datepicker {
+  width: calc(100% - 10px);
   position: absolute;
   z-index: 100;
   box-sizing: border-box;
@@ -285,7 +286,6 @@
 }
 .tui-grid-cell-content select:not(.tui-time-picker-select) {
   box-sizing: border-box;
-  width: 100%;
 }
 .tui-grid-column-resize-container {
   display: none;
@@ -819,4 +819,5 @@
   top: 45%;
   right: 10px;
   margin: -6px 0 0 0;
+  cursor: pointer;
 }

--- a/packages/toast-ui.grid/src/editor/datePicker.ts
+++ b/packages/toast-ui.grid/src/editor/datePicker.ts
@@ -82,11 +82,9 @@ export class DatePickerEditor implements CellEditor {
     }
 
     let date = isUndefined(value) || isNull(value) ? '' : new Date();
-    let format = 'yyyy-MM-dd';
 
-    if (options.format) {
-      format = options.format;
-      delete options.format;
+    if (!options.format) {
+      options.format = 'yyyy-MM-dd';
     }
 
     if (isNumber(value) || isString(value)) {
@@ -98,7 +96,7 @@ export class DatePickerEditor implements CellEditor {
       type: 'date',
       input: {
         element: this.inputEl,
-        format
+        format: options.format
       },
       usageStatistics
     };

--- a/packages/toast-ui.grid/src/editor/datePicker.ts
+++ b/packages/toast-ui.grid/src/editor/datePicker.ts
@@ -11,6 +11,8 @@ export class DatePickerEditor implements CellEditor {
 
   private datePickerEl: TuiDatePicker;
 
+  private iconEl?: HTMLElement;
+
   private createWrapper() {
     const el = document.createElement('div');
     el.className = cls('layer-datepicker');
@@ -34,11 +36,22 @@ export class DatePickerEditor implements CellEditor {
     return calendarWrapper;
   }
 
+  private openDatePicker() {
+    this.datePickerEl.open();
+  }
+
   private createIcon() {
     const icon = document.createElement('i');
     icon.className = cls('date-icon');
+    icon.addEventListener('click', () => {
+      this.openDatePicker();
+    });
 
     return icon;
+  }
+
+  private focus() {
+    this.inputEl.focus();
   }
 
   public constructor(props: CellEditorProps) {
@@ -63,6 +76,7 @@ export class DatePickerEditor implements CellEditor {
 
     if (options.showIcon) {
       const icon = this.createIcon();
+      this.iconEl = icon;
       this.inputEl.className = cls('datepicker-input');
       datepickerInputContainer.appendChild(icon);
     }
@@ -90,6 +104,9 @@ export class DatePickerEditor implements CellEditor {
     };
 
     this.datePickerEl = new TuiDatePicker(calendarWrapper, deepMergedCopy(defaultOptions, options));
+    this.datePickerEl.on('close', () => {
+      this.focus();
+    });
   }
 
   public getElement() {
@@ -106,6 +123,9 @@ export class DatePickerEditor implements CellEditor {
   }
 
   public beforeDestroy() {
+    if (this.iconEl) {
+      this.iconEl.removeEventListener('click', this.openDatePicker);
+    }
     this.datePickerEl.destroy();
   }
 }

--- a/packages/toast-ui.grid/src/grid.tsx
+++ b/packages/toast-ui.grid/src/grid.tsx
@@ -69,11 +69,10 @@ import { getRowSpanByRowKey } from './query/rowSpan';
 import { sendHostname } from './helper/googleAnalytics';
 import { composeConditionFn, getFilterConditionFn } from './helper/filter';
 
-/* eslint-disable */
+/* eslint-disable global-require */
 if ((module as any).hot) {
   require('preact/devtools');
 }
-/* eslint-enable */
 
 /**
  * Grid public API

--- a/packages/toast-ui.grid/src/view/datePickerFilter.tsx
+++ b/packages/toast-ui.grid/src/view/datePickerFilter.tsx
@@ -125,6 +125,10 @@ class DatePickerFilterComp extends Component<Props> {
     return { value, code };
   };
 
+  private openDatePicker = () => {
+    this.datePickerEl!.open();
+  };
+
   public render() {
     const { columnInfo } = this.props;
     const { options } = columnInfo.filter!;
@@ -160,7 +164,7 @@ class DatePickerFilterComp extends Component<Props> {
             onKeyUp={this.handleKeyUp}
             value={value}
           />
-          {showIcon && <i className={cls('date-icon')} />}
+          {showIcon && <i className={cls('date-icon')} onClick={this.openDatePicker} />}
         </div>
         <div
           ref={ref => {

--- a/packages/toast-ui.grid/types/tui-date-picker/index.d.ts
+++ b/packages/toast-ui.grid/types/tui-date-picker/index.d.ts
@@ -19,7 +19,9 @@ declare module 'tui-date-picker' {
     constructor(container: string | HTMLElement, options?: DatePickerOptions);
 
     public open(): void;
+
     public destroy(): void;
+
     public on(type: DatePickerEventType, handler: Function): void;
   }
 }

--- a/packages/toast-ui.grid/webpack.config.js
+++ b/packages/toast-ui.grid/webpack.config.js
@@ -112,7 +112,8 @@ module.exports = (env, { mode = 'development' }) => {
     },
     plugins: [
       new HtmlWebpackPlugin({
-        filename: 'dist/index.html'
+        filename: 'dist/index.html',
+        template: 'index.html'
       })
     ],
     devServer: {

--- a/packages/toast-ui.grid/webpack.config.js
+++ b/packages/toast-ui.grid/webpack.config.js
@@ -28,7 +28,7 @@ const commonConfig = {
     library: ['tui', 'Grid'],
     libraryTarget: 'umd',
     filename: package.name + (minify ? '.min' : '') + '.js',
-    publicPath: '/',
+    publicPath: '/dist',
     path: path.resolve(__dirname, 'dist')
   }
 };


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* focused the editing cell properly when datepicker layer is closed


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
