### PR TITLE
fix: calculate with cell border width when refresh row height

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/columnOptions.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/columnOptions.spec.ts
@@ -183,7 +183,7 @@ describe('cell content ellipsis/whitespace', () => {
       }
     });
 
-    cy.get('.tui-grid-row-odd').should('have.css', 'height', '68px');
+    cy.get('.tui-grid-row-odd').should('have.css', 'height', '69px');
     cy.get('.tui-grid-cell-has-input')
       .eq(2)
       .click()

--- a/packages/toast-ui.grid/src/view/bodyCell.tsx
+++ b/packages/toast-ui.grid/src/view/bodyCell.tsx
@@ -28,6 +28,7 @@ interface StoreProps {
   disabled: boolean;
   treeInfo?: TreeCellInfo;
   selectedRow: boolean;
+  cellBorderWidth: number;
 }
 
 type Props = OwnProps & StoreProps & DispatchProps;
@@ -47,7 +48,8 @@ export class BodyCellComp extends Component<Props> {
       refreshRowHeight,
       disabled: allDisabled,
       defaultRowHeight,
-      dispatch
+      dispatch,
+      cellBorderWidth
     } = this.props;
 
     // eslint-disable-next-line new-cap
@@ -73,7 +75,7 @@ export class BodyCellComp extends Component<Props> {
       //    Container component using setTimeout(fn, 0)
       //  - Delay 16ms for defer the function call later than the Container component.
       window.setTimeout(() => {
-        const height = rendererEl.clientHeight;
+        const height = rendererEl.clientHeight + cellBorderWidth;
         dispatch('setCellHeight', columnInfo.name, rowIndex, height, defaultRowHeight);
         refreshRowHeight(height);
       }, 16);
@@ -96,7 +98,8 @@ export class BodyCellComp extends Component<Props> {
         refreshRowHeight,
         defaultRowHeight,
         disabled: allDisabled,
-        dispatch
+        dispatch,
+        cellBorderWidth
       } = nextProps;
 
       this.renderer.render({
@@ -108,9 +111,11 @@ export class BodyCellComp extends Component<Props> {
       });
 
       if (refreshRowHeight) {
-        const height = this.renderer.getElement().clientHeight;
-        dispatch('setCellHeight', columnInfo.name, rowIndex, height, defaultRowHeight);
-        refreshRowHeight(height);
+        window.setTimeout(() => {
+          const height = this.renderer.getElement().clientHeight + cellBorderWidth;
+          dispatch('setCellHeight', columnInfo.name, rowIndex, height, defaultRowHeight);
+          refreshRowHeight(height);
+        }, 16);
       }
     }
   }
@@ -214,7 +219,7 @@ export const BodyCell = connect<StoreProps, OwnProps>(
     const { range } = selection;
     const columnName = columnInfo.name;
     const rowIndex = findIndexByRowKey(data, column, id, rowKey);
-    const { rowHeight: defaultRowHeight } = dimension;
+    const { rowHeight: defaultRowHeight, cellBorderWidth } = dimension;
     const rowIndexWithPage = isEmpty(pageOptions) ? rowIndex : rowIndex % pageOptions.perPage;
 
     return {
@@ -228,7 +233,8 @@ export const BodyCell = connect<StoreProps, OwnProps>(
       ...(columnName === treeColumnName ? { treeInfo } : null),
       selectedRow: range
         ? rowIndexWithPage >= range.row[0] && rowIndexWithPage <= range.row[1]
-        : false
+        : false,
+      cellBorderWidth
     };
   }
 )(BodyCellComp);

--- a/packages/toast-ui.grid/src/view/bodyCell.tsx
+++ b/packages/toast-ui.grid/src/view/bodyCell.tsx
@@ -39,18 +39,7 @@ export class BodyCellComp extends Component<Props> {
   private el!: HTMLElement;
 
   public componentDidMount() {
-    const {
-      grid,
-      rowKey,
-      rowIndex,
-      renderData,
-      columnInfo,
-      refreshRowHeight,
-      disabled: allDisabled,
-      defaultRowHeight,
-      dispatch,
-      cellBorderWidth
-    } = this.props;
+    const { grid, rowKey, renderData, columnInfo, disabled: allDisabled } = this.props;
 
     // eslint-disable-next-line new-cap
     this.renderer = new columnInfo.renderer.type({
@@ -66,20 +55,7 @@ export class BodyCellComp extends Component<Props> {
     if (this.renderer.mounted) {
       this.renderer.mounted(this.el);
     }
-
-    if (refreshRowHeight) {
-      // In Preact, the componentDidMount is called before the DOM elements are actually mounted.
-      // https://github.com/preactjs/preact/issues/648
-      // Use setTimeout to wait until the DOM element is actually mounted
-      //  - If the width of grid is 'auto' actual width of grid is calculated from the
-      //    Container component using setTimeout(fn, 0)
-      //  - Delay 16ms for defer the function call later than the Container component.
-      window.setTimeout(() => {
-        const height = rendererEl.clientHeight + cellBorderWidth;
-        dispatch('setCellHeight', columnInfo.name, rowIndex, height, defaultRowHeight);
-        refreshRowHeight(height);
-      }, 16);
-    }
+    this.calculateRowHeight(this.props);
   }
 
   public componentWillReceiveProps(nextProps: Props) {
@@ -89,18 +65,7 @@ export class BodyCellComp extends Component<Props> {
       this.renderer &&
       this.renderer.render
     ) {
-      const {
-        grid,
-        rowKey,
-        rowIndex,
-        renderData,
-        columnInfo,
-        refreshRowHeight,
-        defaultRowHeight,
-        disabled: allDisabled,
-        dispatch,
-        cellBorderWidth
-      } = nextProps;
+      const { grid, rowKey, renderData, columnInfo, disabled: allDisabled } = nextProps;
 
       this.renderer.render({
         grid,
@@ -109,14 +74,7 @@ export class BodyCellComp extends Component<Props> {
         ...renderData,
         allDisabled
       });
-
-      if (refreshRowHeight) {
-        window.setTimeout(() => {
-          const height = this.renderer.getElement().clientHeight + cellBorderWidth;
-          dispatch('setCellHeight', columnInfo.name, rowIndex, height, defaultRowHeight);
-          refreshRowHeight(height);
-        }, 16);
-      }
+      this.calculateRowHeight(nextProps);
     }
   }
 
@@ -149,6 +107,31 @@ export class BodyCellComp extends Component<Props> {
   private handleSelectStart = (ev: Event) => {
     ev.preventDefault();
   };
+
+  private calculateRowHeight(props: Props) {
+    const {
+      rowIndex,
+      columnInfo,
+      refreshRowHeight,
+      defaultRowHeight,
+      dispatch,
+      cellBorderWidth
+    } = props;
+
+    if (refreshRowHeight) {
+      // In Preact, the componentDidMount is called before the DOM elements are actually mounted.
+      // https://github.com/preactjs/preact/issues/648
+      // Use setTimeout to wait until the DOM element is actually mounted
+      //  - If the width of grid is 'auto' actual width of grid is calculated from the
+      //    Container component using setTimeout(fn, 0)
+      //  - Delay 16ms for defer the function call later than the Container component.
+      window.setTimeout(() => {
+        const height = this.renderer.getElement().clientHeight + cellBorderWidth;
+        dispatch('setCellHeight', columnInfo.name, rowIndex, height, defaultRowHeight);
+        refreshRowHeight(height);
+      }, 16);
+    }
+  }
 
   public render() {
     const {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* calculated with cell border width when refresh row height
  * need to add visual test in storybook
  * bug page: https://nhn.github.io/tui.grid/latest/tutorial-example12-whitespace

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
