### PR TITLE
refactor: setting rowKey in setRow api

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/modifiedDataManager.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/modifiedDataManager.spec.ts
@@ -72,16 +72,26 @@ it('should not add the created row to updatedRows, regardless of modifying it', 
   assertModifiedRowsContainsObject({ createdRows: [{ name: 'RYU', age: 30 }] });
 });
 
-it('should add updated row to updateRows property once, regardless of modifying it in many times', () => {
-  cy.gridInstance().invoke('appendRow', { name: 'Park', age: 30 });
-  cy.gridInstance().invoke('setValue', 2, 'age', 20);
-  cy.gridInstance().invoke('setValue', 0, 'name', 'RYU');
-  cy.gridInstance().invoke('setValue', 0, 'name', 'JIN');
+describe('update rows', () => {
+  it('should add updated row to updateRows property once, when modified by setValue API in multiple times', () => {
+    cy.gridInstance().invoke('appendRow', { name: 'Park', age: 30 });
+    cy.gridInstance().invoke('setValue', 2, 'age', 20);
+    cy.gridInstance().invoke('setValue', 0, 'name', 'RYU');
+    cy.gridInstance().invoke('setValue', 0, 'name', 'JIN');
 
-  assertModifiedRowsLength({ createdRows: 1, updatedRows: 1, deletedRows: 0 });
-  assertModifiedRowsContainsObject({
-    createdRows: [{ name: 'Park', age: 20 }],
-    updatedRows: [{ name: 'JIN', age: 10 }]
+    assertModifiedRowsLength({ createdRows: 1, updatedRows: 1, deletedRows: 0 });
+    assertModifiedRowsContainsObject({
+      createdRows: [{ name: 'Park', age: 20 }],
+      updatedRows: [{ name: 'JIN', age: 10 }]
+    });
+  });
+
+  it('should add updated row to updateRows property once, when modified by setRow API in multiple times', () => {
+    cy.gridInstance().invoke('setRow', 0, { name: 'Park', age: 30 });
+    cy.gridInstance().invoke('setRow', 0, { name: 'JIN', age: 10 });
+
+    assertModifiedRowsLength({ createdRows: 0, updatedRows: 1, deletedRows: 0 });
+    assertModifiedRowsContainsObject({ updatedRows: [{ name: 'JIN', age: 10 }] });
   });
 });
 

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -794,7 +794,7 @@ export function updateRowNumber({ data }: Store, startIndex: number) {
 }
 
 export function setRow(store: Store, rowIndex: number, row: OptRow) {
-  const { data, id, focus } = store;
+  const { data, id } = store;
   const { rawData, viewData, sortState } = data;
   const orgRow = rawData[rowIndex];
 
@@ -803,14 +803,7 @@ export function setRow(store: Store, rowIndex: number, row: OptRow) {
   }
 
   row.sortKey = orgRow.sortKey;
-  const { rawRow, viewRow, prevRow } = getCreatedRowInfo(store, rowIndex, row);
-  // @TODO: should change to create rowKey
-  rawRow.rowKey = orgRow.rowKey;
-  viewRow.rowKey = orgRow.rowKey;
-
-  if (someProp('rowKey', focus.rowKey, rawData)) {
-    initFocus(store);
-  }
+  const { rawRow, viewRow, prevRow } = getCreatedRowInfo(store, rowIndex, row, orgRow.rowKey);
 
   viewData.splice(rowIndex, 1, viewRow);
   rawData.splice(rowIndex, 1, rawRow);

--- a/packages/toast-ui.grid/src/query/data.ts
+++ b/packages/toast-ui.grid/src/query/data.ts
@@ -1,4 +1,13 @@
-import { Store, RowKey, Data, Row, Dictionary, Column, SortState } from '../store/types';
+import {
+  Store,
+  RowKey,
+  Data,
+  Row,
+  Dictionary,
+  Column,
+  SortState,
+  RawRowOptions
+} from '../store/types';
 import {
   isFunction,
   findPropIndex,
@@ -174,17 +183,23 @@ export function getRemovedClassName(className: string, prevClassNames: string[])
   return removedClassNames;
 }
 
-export function getCreatedRowInfo(store: Store, rowIndex: number, row: OptRow) {
+export function getCreatedRowInfo(store: Store, rowIndex: number, row: OptRow, rowKey?: RowKey) {
   const { data, column } = store;
   const { rawData } = data;
   const { defaultValues, allColumnMap } = column;
   const prevRow = rawData[rowIndex - 1];
+  const options: RawRowOptions = { prevRow };
+
+  if (!isUndefined(rowKey)) {
+    row.rowKey = rowKey;
+    options.keyColumnName = 'rowKey';
+  }
 
   const emptyData = column.allColumns
     .filter(({ name }) => !isRowHeader(name))
     .reduce((acc, { name }) => ({ ...acc, [name]: '' }), {});
   const index = Math.max(-1, ...(mapProp('rowKey', rawData) as number[])) + 1;
-  const rawRow = createRawRow({ ...emptyData, ...row }, index, defaultValues);
+  const rawRow = createRawRow({ ...emptyData, ...row }, index, defaultValues, options);
   const viewRow = createViewRow(rawRow, allColumnMap, rawData);
 
   return { rawRow, viewRow, prevRow };

--- a/packages/toast-ui.grid/src/store/data.ts
+++ b/packages/toast-ui.grid/src/store/data.ts
@@ -19,7 +19,8 @@ import {
   ViewRow,
   Range,
   Filter,
-  RowSpan
+  RowSpan,
+  RawRowOptions
 } from './types';
 import { observable, observe, Observable } from '../helper/observable';
 import { isRowHeader, isRowNumColumn, isCheckboxColumn } from '../helper/column';
@@ -49,12 +50,6 @@ interface DataOption {
   useClientSort: boolean;
   disabled: boolean;
   id: number;
-}
-
-interface RawRowOptions {
-  keyColumnName?: string;
-  prevRow?: Row;
-  lazyObservable?: boolean;
 }
 
 let dataCreationKey = '';
@@ -395,6 +390,7 @@ export function createRawRow(
   if (row._attributes) {
     rowSpan = row._attributes.rowSpan as RowSpanAttributeValue;
   }
+
   row.rowKey = keyColumnName ? row[keyColumnName] : index;
   row.sortKey = isNumber(row.sortKey) ? row.sortKey : index;
   row.uniqueKey = `${dataCreationKey}-${row.rowKey}`;

--- a/packages/toast-ui.grid/src/store/types.ts
+++ b/packages/toast-ui.grid/src/store/types.ts
@@ -506,3 +506,9 @@ export interface ComplexColumnInfo {
   headerRenderer?: HeaderRendererClass | null;
   hideChildHeaders?: boolean;
 }
+
+export interface RawRowOptions {
+  keyColumnName?: string;
+  prevRow?: Row;
+  lazyObservable?: boolean;
+}


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* changed setting rowKey on calling `setRow` API
  * before
    ```js
    const { rawRow, viewRow, prevRow } = getCreatedRowInfo(store, rowIndex, row);
    rawRow.rowKey = orgRow.rowKey;
    viewRow.rowKey = orgRow.rowKey;
    ```
  * after
    ```js
    const { rawRow, viewRow, prevRow } = getCreatedRowInfo(store, rowIndex, row, orgRow.rowKey);
    ```
* removed to call function to initialize focus layer


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
