### PR TITLE
fix: add the preventScroll option to the clipboard element (fix #823)

### DIFF
--- a/packages/toast-ui.grid/src/view/clipboard.tsx
+++ b/packages/toast-ui.grid/src/view/clipboard.tsx
@@ -212,7 +212,7 @@ class ClipboardComp extends Component<Props> {
         !this.isClipboardFocused() &&
         !isMobile()
       ) {
-        this.el.focus();
+        this.el.focus({ preventScroll: true });
       }
     });
   }

--- a/packages/toast-ui.grid/stories/focus.stories.ts
+++ b/packages/toast-ui.grid/stories/focus.stories.ts
@@ -13,7 +13,7 @@ type Options = {
 
 function blur(el: HTMLElement) {
   setTimeout(() => {
-    (el.querySelector('.tui-grid-clipboard') as HTMLElement).focus();
+    (el.querySelector('.tui-grid-clipboard') as HTMLElement).focus({ preventScroll: true });
     (el.querySelector('.tui-grid-clipboard') as HTMLElement).blur();
   });
 }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->


### Description

This PR solves the problem I experienced in #823.

The `{ preventScroll: true }` option when calling `.focus()` in the clipboard element shouln't cause any problem because that element is meant to be hidden.

Reference: https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/focus

