### PR TITLE
fix: reorder process order of  and event(#838)

### DIFF
--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -283,6 +283,13 @@ export function check(store: Store, rowKey: RowKey) {
   const eventBus = getEventBus(id);
   const gridEvent = new GridEvent({ rowKey });
 
+  setRowAttribute(store, rowKey, 'checked', true);
+  setCheckedAllRows(store);
+
+  if (allColumnMap[treeColumnName]) {
+    changeTreeRowsCheckedState(store, rowKey, true);
+  }
+
   /**
    * Occurs when a checkbox in row header is checked
    * @event Grid#check
@@ -290,13 +297,6 @@ export function check(store: Store, rowKey: RowKey) {
    * @property {Grid} instance - Current grid instance
    */
   eventBus.trigger('check', gridEvent);
-
-  setRowAttribute(store, rowKey, 'checked', true);
-  setCheckedAllRows(store);
-
-  if (allColumnMap[treeColumnName]) {
-    changeTreeRowsCheckedState(store, rowKey, true);
-  }
 }
 
 export function uncheck(store: Store, rowKey: RowKey) {
@@ -305,6 +305,13 @@ export function uncheck(store: Store, rowKey: RowKey) {
   const eventBus = getEventBus(id);
   const gridEvent = new GridEvent({ rowKey });
 
+  setRowAttribute(store, rowKey, 'checked', false);
+  setCheckedAllRows(store);
+
+  if (allColumnMap[treeColumnName]) {
+    changeTreeRowsCheckedState(store, rowKey, false);
+  }
+
   /**
    * Occurs when a checkbox in row header is unchecked
    * @event Grid#uncheck
@@ -312,13 +319,6 @@ export function uncheck(store: Store, rowKey: RowKey) {
    * @property {Grid} instance - Current grid instance
    */
   eventBus.trigger('uncheck', gridEvent);
-
-  setRowAttribute(store, rowKey, 'checked', false);
-  setCheckedAllRows(store);
-
-  if (allColumnMap[treeColumnName]) {
-    changeTreeRowsCheckedState(store, rowKey, false);
-  }
 }
 
 export function checkAll(store: Store, allPage = true) {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

related issue: #838 
`check`, `uncheck` events are triggered before set the checked property.
so, have reordered that process.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
