### PR TITLE
feat: add validatorFn parameters(#910)

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/validation.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/validation.spec.ts
@@ -111,7 +111,7 @@ describe('should check the validation of cell - validatorFn', () => {
     cy.getCell(0, 'name').should('have.class', cls('cell-invalid'));
   });
 
-  it.only('`value`, `rowKey`, `columnName` should be passed as the parameters of validatorFn ', () => {
+  it('`value`, `row`, `columnName` should be passed as the parameters of validatorFn ', () => {
     const callback = cy.stub();
 
     cy.createGrid({
@@ -127,7 +127,7 @@ describe('should check the validation of cell - validatorFn', () => {
     });
 
     cy.wrap(callback).should('be.calledWithMatch', 'note', { rowKey: 0, name: 'note' }, 'name');
-    cy.wrap(callback).should('be.calledWithMatch', 'pen', 1, { rowKey: 1, name: 'pen' }, 'name');
+    cy.wrap(callback).should('be.calledWithMatch', 'pen', { rowKey: 1, name: 'pen' }, 'name');
   });
 });
 

--- a/packages/toast-ui.grid/cypress/integration/validation.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/validation.spec.ts
@@ -111,7 +111,7 @@ describe('should check the validation of cell - validatorFn', () => {
     cy.getCell(0, 'name').should('have.class', cls('cell-invalid'));
   });
 
-  it('`value`, `rowKey`, `columnName` should be passed as the parameters of validatorFn ', () => {
+  it.only('`value`, `rowKey`, `columnName` should be passed as the parameters of validatorFn ', () => {
     const callback = cy.stub();
 
     cy.createGrid({
@@ -126,8 +126,8 @@ describe('should check the validation of cell - validatorFn', () => {
       ]
     });
 
-    cy.wrap(callback).should('be.calledWithMatch', 'note', 0, 'name');
-    cy.wrap(callback).should('be.calledWithMatch', 'pen', 1, 'name');
+    cy.wrap(callback).should('be.calledWithMatch', 'note', { rowKey: 0, name: 'note' }, 'name');
+    cy.wrap(callback).should('be.calledWithMatch', 'pen', 1, { rowKey: 1, name: 'pen' }, 'name');
   });
 });
 

--- a/packages/toast-ui.grid/index.d.ts
+++ b/packages/toast-ui.grid/index.d.ts
@@ -356,7 +356,7 @@ declare namespace tuiGrid {
     min?: number;
     max?: number;
     regExp?: RegExp;
-    validatorFn?: (value: CellValue) => boolean;
+    validatorFn?: (value: CellValue, rowKey: RowKey, columnName: string) => boolean;
   }
 
   interface InvalidColumn {

--- a/packages/toast-ui.grid/index.d.ts
+++ b/packages/toast-ui.grid/index.d.ts
@@ -356,7 +356,7 @@ declare namespace tuiGrid {
     min?: number;
     max?: number;
     regExp?: RegExp;
-    validatorFn?: (value: CellValue, rowKey: RowKey, columnName: string) => boolean;
+    validatorFn?: (value: CellValue, row: Row, columnName: string) => boolean;
   }
 
   interface InvalidColumn {

--- a/packages/toast-ui.grid/src/store/data.ts
+++ b/packages/toast-ui.grid/src/store/data.ts
@@ -144,20 +144,22 @@ function getValidationCode(
   }
 
   const { required, dataType, min, max, regExp, validatorFn } = validation;
-  const originRow = omit(
-    getOriginObject(row as Observable<Row>),
-    'sortKey',
-    'uniqueKey',
-    '_relationListItemMap',
-    '_disabledPriority'
-  ) as Row;
 
   if (required && isBlank(value)) {
     invalidStates.push('REQUIRED');
   }
 
-  if (validatorFn && !validatorFn(value, originRow, columnName)) {
-    invalidStates.push('VALIDATOR_FN');
+  if (isFunction(validatorFn)) {
+    const originRow = omit(
+      getOriginObject(row as Observable<Row>),
+      'sortKey',
+      'uniqueKey',
+      '_relationListItemMap',
+      '_disabledPriority'
+    ) as Row;
+    if (!validatorFn(value, originRow, columnName)) {
+      invalidStates.push('VALIDATOR_FN');
+    }
   }
 
   if (dataType === 'string' && !isString(value)) {

--- a/packages/toast-ui.grid/src/store/data.ts
+++ b/packages/toast-ui.grid/src/store/data.ts
@@ -130,7 +130,12 @@ function getRowHeaderValue(row: Row, columnName: string) {
   return '';
 }
 
-function getValidationCode(value: CellValue, validation?: Validation): ValidationType[] {
+function getValidationCode(
+  value: CellValue,
+  rowKey: RowKey,
+  columnName: string,
+  validation?: Validation
+) {
   const invalidStates: ValidationType[] = [];
 
   if (!validation) {
@@ -143,7 +148,7 @@ function getValidationCode(value: CellValue, validation?: Validation): Validatio
     invalidStates.push('REQUIRED');
   }
 
-  if (validatorFn && !validatorFn(value)) {
+  if (validatorFn && !validatorFn(value, rowKey, columnName)) {
     invalidStates.push('VALIDATOR_FN');
   }
 
@@ -214,7 +219,7 @@ function createViewCell(
     editable: !!editor,
     className,
     disabled: cellDisabled,
-    invalidStates: getValidationCode(value, validation),
+    invalidStates: getValidationCode(value, row.rowKey, name, validation),
     formattedValue: getFormattedValue(formatterProps, formatter, value, relationListItems),
     value
   };

--- a/packages/toast-ui.grid/src/store/types.ts
+++ b/packages/toast-ui.grid/src/store/types.ts
@@ -149,7 +149,7 @@ export interface Validation {
   min?: number;
   max?: number;
   regExp?: RegExp;
-  validatorFn?: (value: CellValue, rowKey: RowKey, columnName: string) => boolean;
+  validatorFn?: (value: CellValue, row: Row, columnName: string) => boolean;
 }
 
 export interface InvalidColumn {

--- a/packages/toast-ui.grid/src/store/types.ts
+++ b/packages/toast-ui.grid/src/store/types.ts
@@ -149,7 +149,7 @@ export interface Validation {
   min?: number;
   max?: number;
   regExp?: RegExp;
-  validatorFn?: (value: CellValue) => boolean;
+  validatorFn?: (value: CellValue, rowKey: RowKey, columnName: string) => boolean;
 }
 
 export interface InvalidColumn {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* related issue(#910)
* additional context
  * the `row`(not `rowKey`) should be passed  as the parameter, because when `validatorFn` is executed the grid instance is not created yet.
   ```js
   const grid = new tui.Grid({
     el,
     data,
     columns: [
       {
         header: 'Price',
         name: 'price',
         validation: {
           validatorFn: (value, row, columnName) => {
             // cannot use as below, because the grid instance is not created on calling `validatorFn`
             // grid.getValue(row.rowKey, columnName);

             return value !== 11000
           }
         }
       },
       // ...
     ]
   });
   ```


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
