### PR TITLE
fix: Filter UI is hidden when the Grid is on the far right(#812)

### DIFF
--- a/packages/toast-ui.grid/src/view/filterLayerInner.tsx
+++ b/packages/toast-ui.grid/src/view/filterLayerInner.tsx
@@ -24,6 +24,16 @@ interface OwnProps {
 type Props = StoreProps & OwnProps & DispatchProps;
 
 export class FilterLayerInnerComp extends Component<Props> {
+  private calculateLeft() {
+    const { width } = this.context.store.dimension;
+    const { left } = this.props.columnAddress;
+
+    if (left + 230 > width) {
+      return width - 230;
+    }
+    return left;
+  }
+
   private renderFilter = (index: number) => {
     const { columnAddress, filterState, columnInfo } = this.props;
     const type = columnInfo.filter!.type;
@@ -51,7 +61,6 @@ export class FilterLayerInnerComp extends Component<Props> {
 
   public render() {
     const {
-      columnAddress,
       columnInfo,
       renderSecondFilter,
       dispatch,
@@ -59,10 +68,9 @@ export class FilterLayerInnerComp extends Component<Props> {
       filterState
     } = this.props;
     const { showApplyBtn, showClearBtn } = columnInfo.filter!;
-    const { left } = columnAddress;
 
     return (
-      <div className={cls('filter-container')} style={{ left }}>
+      <div className={cls('filter-container')} style={{ left: this.calculateLeft() }}>
         <div>
           <span
             className={cls('btn-filter', [currentColumnActive, 'btn-filter-active'], 'filter-icon')}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

Hello. long time no see.
Register Pull Request for previously registered issues

The layout of the filter is out of the grid container.

Before: (Red box is grid container)
![image](https://user-images.githubusercontent.com/18422353/74630281-97fee080-519d-11ea-9e04-fe785b0de028.png)


After: (Red box is grid container)
![image](https://user-images.githubusercontent.com/18422353/74630295-a1884880-519d-11ea-87cd-356d4bb512d4.png)

Thanks.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
