### PR TITLE
fix: check disabled, editable state in setColumnValuesAPI

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/column.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/column.spec.ts
@@ -99,7 +99,7 @@ describe('API', () => {
       { id: 1, name: 'Kim', score: 90, grade: 'A' },
       { id: 2, name: 'Lee', score: 80, grade: 'B' }
     ];
-    const columns = [{ name: 'name' }, { name: 'score' }];
+    const columns = [{ name: 'name' }, { name: 'score', disabled: true }];
     cy.createGrid({ data, columns });
   });
 
@@ -109,10 +109,19 @@ describe('API', () => {
       .should('eql', ['Kim', 'Lee']);
   });
 
-  it('setColumnValues()', () => {
-    cy.gridInstance().invoke('setColumnValues', 'name', 'Park');
+  context('setColumnValues()', () => {
+    it('should change values of specific column', () => {
+      cy.gridInstance().invoke('setColumnValues', 'name', 'Park');
 
-    cy.getColumnCells('name').should('sameColumnData', 'Park');
+      cy.getColumnCells('name').should('sameColumnData', 'Park');
+    });
+
+    it('should not change values of disabled cell with checkCellState: true', () => {
+      cy.gridInstance().invoke('setColumnValues', 'score', '100', true);
+
+      cy.getCell(0, 'score').should('have.text', '90');
+      cy.getCell(1, 'score').should('have.text', '80');
+    });
   });
 
   it('getIndexOfColumn()', () => {

--- a/packages/toast-ui.grid/cypress/integration/data.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/data.spec.ts
@@ -425,30 +425,7 @@ describe('rows', () => {
   });
 });
 
-describe('focus', () => {
-  beforeEach(() => {
-    createGrid();
-  });
-
-  it('should destroy the focusing layer, when hide the column', () => {
-    cy.gridInstance().invoke('focus', 1, 'name', true);
-    cy.gridInstance().invoke('hideColumn', 'name');
-    cy.gridInstance()
-      .invoke('getFocusedCell')
-      .should('eql', { columnName: null, rowKey: null, value: null });
-  });
-
-  it('cannot focus the cell on hidden cell', () => {
-    cy.gridInstance().invoke('hideColumn', 'name');
-    cy.gridInstance().invoke('focus', 1, 'name');
-
-    cy.gridInstance()
-      .invoke('getFocusedCell')
-      .should('eql', { columnName: null, rowKey: null, value: null });
-  });
-});
-
-describe('setRow', () => {
+describe('setRow()', () => {
   it('should not replace the row when target rowKey does not exist in grid', () => {
     createGrid();
 
@@ -508,7 +485,7 @@ describe('setRow', () => {
   });
 });
 
-describe('moveRow', () => {
+describe('moveRow()', () => {
   beforeEach(() => {
     createGridWithLargeData();
   });
@@ -569,7 +546,7 @@ it('row._attributes should be maintained on calling resetData', () => {
     .should('be.checked');
 });
 
-describe('appendRows', () => {
+describe('appendRows()', () => {
   it('should append rows to existing data', () => {
     createGrid();
 
@@ -616,6 +593,32 @@ describe('appendRows', () => {
       ['Lee', '20'],
       ['Lee', '30'],
       ['Lee', '40']
+    ]);
+  });
+});
+
+describe('setValue()', () => {
+  beforeEach(() => {
+    const columns = [{ name: 'name' }, { name: 'age' }];
+    // @ts-ignore
+    createGrid({ columns });
+  });
+
+  it('should change the value of the cell', () => {
+    cy.gridInstance().invoke('setValue', 0, 'name', 'Han');
+
+    cy.getRsideBody().should('have.cellData', [
+      ['Han', '10'],
+      ['Lee', '20']
+    ]);
+  });
+
+  it('should not change the value of the cell with checkCellState', () => {
+    cy.gridInstance().invoke('setValue', 0, 'name', 'Han', true);
+
+    cy.getRsideBody().should('have.cellData', [
+      ['Kim', '10'],
+      ['Lee', '20']
     ]);
   });
 });

--- a/packages/toast-ui.grid/cypress/integration/focus.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/focus.spec.ts
@@ -113,3 +113,35 @@ describe('scroll position following focused cell', () => {
     });
   });
 });
+
+describe('should not display the focus layer', () => {
+  beforeEach(() => {
+    const data = [
+      { name: 'Kim', age: 10 },
+      { name: 'Lee', age: 20 }
+    ];
+    const columns = [
+      { name: 'name', editor: 'text' },
+      { name: 'age', editor: 'text' }
+    ];
+
+    cy.createGrid({ data, columns });
+  });
+
+  it('should destroy the focusing layer, when hide the column', () => {
+    cy.gridInstance().invoke('focus', 1, 'name', true);
+    cy.gridInstance().invoke('hideColumn', 'name');
+    cy.gridInstance()
+      .invoke('getFocusedCell')
+      .should('eql', { columnName: null, rowKey: null, value: null });
+  });
+
+  it('cannot focus the cell on hidden cell', () => {
+    cy.gridInstance().invoke('hideColumn', 'name');
+    cy.gridInstance().invoke('focus', 1, 'name');
+
+    cy.gridInstance()
+      .invoke('getFocusedCell')
+      .should('eql', { columnName: null, rowKey: null, value: null });
+  });
+});

--- a/packages/toast-ui.grid/cypress/integration/modifiedDataManager.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/modifiedDataManager.spec.ts
@@ -70,29 +70,21 @@ it('should not add the created row to updatedRows, regardless of modifying it', 
 });
 
 describe('update rows', () => {
-  it('should add updated row to updateRows property once, when modified by setValue API in multiple times', () => {
-    cy.gridInstance().invoke('appendRow', { name: 'Park', age: 30 });
-    cy.gridInstance().invoke('setValue', 2, 'age', 20);
+  it('should add updated row, when row is modified by setValue API', () => {
     cy.gridInstance().invoke('setValue', 0, 'name', 'RYU');
-    cy.gridInstance().invoke('setValue', 0, 'name', 'JIN');
 
-    assertModifiedRowsLength({ createdRows: 1, updatedRows: 1, deletedRows: 0 });
-    assertModifiedRowsContainsObject({
-      createdRows: [{ name: 'Park', age: 20 }],
-      updatedRows: [{ name: 'JIN', age: 10 }]
-    });
+    assertModifiedRowsLength({ createdRows: 0, updatedRows: 1, deletedRows: 0 });
+    assertModifiedRowsContainsObject({ updatedRows: [{ name: 'RYU', age: 10 }] });
   });
 
-  it('should add updated row to updateRows property once, when modified by setRow API in multiple times', () => {
-    cy.gridInstance().invoke('setRow', 0, { name: 'Park', age: 30 });
+  it('should add updated row, when row is modified by setRow API', () => {
     cy.gridInstance().invoke('setRow', 0, { name: 'JIN', age: 10 });
 
     assertModifiedRowsLength({ createdRows: 0, updatedRows: 1, deletedRows: 0 });
     assertModifiedRowsContainsObject({ updatedRows: [{ name: 'JIN', age: 10 }] });
   });
 
-  it('should add updated row to updateRows property once, when modified by setColumnValues API', () => {
-    cy.gridInstance().invoke('setColumnValues', 'name', 'Park');
+  it('should add updated row, when row is modified by setColumnValues API', () => {
     cy.gridInstance().invoke('setColumnValues', 'name', 'Park');
 
     assertModifiedRowsLength({ createdRows: 0, updatedRows: 2, deletedRows: 0 });
@@ -100,6 +92,35 @@ describe('update rows', () => {
       updatedRows: [
         { name: 'Park', age: 10 },
         { name: 'Park', age: 20 }
+      ]
+    });
+  });
+
+  it('should not add duplicated row to updatedRows by calling setValue many times', () => {
+    cy.gridInstance().invoke('setValue', 0, 'name', 'RYU');
+    cy.gridInstance().invoke('setValue', 0, 'name', 'JIN');
+
+    assertModifiedRowsLength({ createdRows: 0, updatedRows: 1, deletedRows: 0 });
+    assertModifiedRowsContainsObject({ updatedRows: [{ name: 'JIN', age: 10 }] });
+  });
+
+  it('should not add duplicated row to updatedRows by calling setRow many times', () => {
+    cy.gridInstance().invoke('setRow', 0, { name: 'Park', age: 30 });
+    cy.gridInstance().invoke('setRow', 0, { name: 'JIN', age: 10 });
+
+    assertModifiedRowsLength({ createdRows: 0, updatedRows: 1, deletedRows: 0 });
+    assertModifiedRowsContainsObject({ updatedRows: [{ name: 'JIN', age: 10 }] });
+  });
+
+  it('should not add duplicated row to updatedRows by calling setColumnValues many times', () => {
+    cy.gridInstance().invoke('setColumnValues', 'name', 'Park');
+    cy.gridInstance().invoke('setColumnValues', 'name', 'Kim');
+
+    assertModifiedRowsLength({ createdRows: 0, updatedRows: 2, deletedRows: 0 });
+    assertModifiedRowsContainsObject({
+      updatedRows: [
+        { name: 'Kim', age: 10 },
+        { name: 'Kim', age: 20 }
       ]
     });
   });

--- a/packages/toast-ui.grid/cypress/integration/modifiedDataManager.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/modifiedDataManager.spec.ts
@@ -90,6 +90,19 @@ describe('update rows', () => {
     assertModifiedRowsLength({ createdRows: 0, updatedRows: 1, deletedRows: 0 });
     assertModifiedRowsContainsObject({ updatedRows: [{ name: 'JIN', age: 10 }] });
   });
+
+  it('should add updated row to updateRows property once, when modified by setColumnValues API', () => {
+    cy.gridInstance().invoke('setColumnValues', 'name', 'Park');
+    cy.gridInstance().invoke('setColumnValues', 'name', 'Park');
+
+    assertModifiedRowsLength({ createdRows: 0, updatedRows: 2, deletedRows: 0 });
+    assertModifiedRowsContainsObject({
+      updatedRows: [
+        { name: 'Park', age: 10 },
+        { name: 'Park', age: 20 }
+      ]
+    });
+  });
 });
 
 it('should add deleted row to only deletedRows property, regardless of modifying it before', () => {

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -194,7 +194,7 @@ export function updatePageOptions(
 export function makeObservable(store: Store, rowKey: RowKey) {
   const { data, column, id } = store;
   const { rawData, viewData } = data;
-  const { columnMapWithRelation, treeColumnName, treeIcon, defaultValues } = column;
+  const { columnMapWithRelation, treeColumnName, treeIcon } = column;
   const foundIndex = findIndexByRowKey(data, column, id, rowKey, false);
   const rawRow = rawData[foundIndex];
 
@@ -204,12 +204,7 @@ export function makeObservable(store: Store, rowKey: RowKey) {
 
   if (treeColumnName) {
     const parentRow = findRowByRowKey(data, column, id, rawRow._attributes.tree!.parentRowKey);
-    rawData[foundIndex] = createTreeRawRow(
-      rawRow,
-      column.defaultValues,
-      parentRow || null,
-      columnMapWithRelation
-    );
+    rawData[foundIndex] = createTreeRawRow(rawRow, parentRow || null, columnMapWithRelation);
     viewData[foundIndex] = createViewRow(
       rawData[foundIndex],
       columnMapWithRelation,
@@ -218,7 +213,7 @@ export function makeObservable(store: Store, rowKey: RowKey) {
       treeIcon
     );
   } else {
-    rawData[foundIndex] = createRawRow(rawRow, foundIndex, defaultValues, columnMapWithRelation);
+    rawData[foundIndex] = createRawRow(rawRow, foundIndex, columnMapWithRelation);
     viewData[foundIndex] = createViewRow(rawData[foundIndex], columnMapWithRelation, rawData);
   }
   notify(data, 'rawData');

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -30,7 +30,8 @@ import {
   createData,
   generateDataCreationKey,
   createRowSpan,
-  setRowRelationListItems
+  setRowRelationListItems,
+  createRawRow
 } from '../store/data';
 import { notify, isObservable } from '../helper/observable';
 import { changeSelectionRange, initSelection } from './selection';
@@ -190,16 +191,66 @@ export function updatePageOptions(
   }
 }
 
-export function setValue(store: Store, rowKey: RowKey, columnName: string, value: CellValue) {
+export function makeObservable(store: Store, rowKey: RowKey) {
+  const { data, column, id } = store;
+  const { rawData, viewData } = data;
+  const { columnMapWithRelation, treeColumnName, treeIcon, defaultValues } = column;
+  const foundIndex = findIndexByRowKey(data, column, id, rowKey, false);
+  const rawRow = rawData[foundIndex];
+
+  if (isObservable(rawRow)) {
+    return;
+  }
+
+  if (treeColumnName) {
+    const parentRow = findRowByRowKey(data, column, id, rawRow._attributes.tree!.parentRowKey);
+    rawData[foundIndex] = createTreeRawRow(
+      rawRow,
+      column.defaultValues,
+      parentRow || null,
+      columnMapWithRelation
+    );
+    viewData[foundIndex] = createViewRow(
+      rawData[foundIndex],
+      columnMapWithRelation,
+      rawData,
+      treeColumnName,
+      treeIcon
+    );
+  } else {
+    rawData[foundIndex] = createRawRow(rawRow, foundIndex, defaultValues, columnMapWithRelation);
+    viewData[foundIndex] = createViewRow(rawData[foundIndex], columnMapWithRelation, rawData);
+  }
+  notify(data, 'rawData');
+  notify(data, 'viewData');
+}
+
+export function setValue(
+  store: Store,
+  rowKey: RowKey,
+  columnName: string,
+  value: CellValue,
+  checkCellState = false
+) {
   let gridEvent;
   const { column, data, id } = store;
-  const { rawData, sortState } = data;
+  const { rawData, viewData, sortState } = data;
   const { visibleColumns, allColumnMap } = column;
   const rowIdx = findIndexByRowKey(data, column, id, rowKey, false);
   const targetRow = rawData[rowIdx];
+
   if (!targetRow || targetRow[columnName] === value) {
     return;
   }
+  if (checkCellState) {
+    makeObservable(store, rowKey);
+    const { disabled, editable } = viewData[rowIdx].valueMap[columnName];
+
+    if (disabled || !editable) {
+      return;
+    }
+  }
+
   const targetColumn = findProp('name', columnName, visibleColumns);
   const orgValue = targetRow[columnName];
 
@@ -282,7 +333,6 @@ export function setColumnValues(
   store: Store,
   columnName: string,
   value: CellValue,
-  // @TODO: need checkCellState in setValue API?
   checkCellState = false
 ) {
   if (checkCellState) {

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -282,12 +282,20 @@ export function setColumnValues(
   store: Store,
   columnName: string,
   value: CellValue,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // @TODO: need checkCellState in setValue API?
   checkCellState = false
 ) {
-  // @TODO Check Cell State
-  store.data.rawData.forEach(targetRow => {
-    targetRow[columnName] = value;
+  if (checkCellState) {
+    // @TODO: find more practical way to make observable
+    createObservableData(store, true);
+  }
+  const { id, data } = store;
+  data.rawData.forEach((targetRow, index) => {
+    const { disabled, editable } = data.viewData[index].valueMap[columnName];
+    if (targetRow[columnName] !== value && (!checkCellState || (!disabled && editable))) {
+      targetRow[columnName] = value;
+      getDataManager(id).push('UPDATE', targetRow);
+    }
   });
   updateSummaryValueByColumn(store, columnName, { value });
 }

--- a/packages/toast-ui.grid/src/dispatch/focus.ts
+++ b/packages/toast-ui.grid/src/dispatch/focus.ts
@@ -1,44 +1,12 @@
 import { Store, RowKey, CellValue } from '../store/types';
 import GridEvent from '../event/gridEvent';
 import { getEventBus } from '../event/eventBus';
-import { isEditableCell, findIndexByRowKey, findRowByRowKey } from '../query/data';
+import { isEditableCell, findIndexByRowKey } from '../query/data';
 import { isFocusedCell, isEditingCell } from '../query/focus';
 import { getRowSpanByRowKey, isRowSpanEnabled } from '../query/rowSpan';
-import { createRawRow, createViewRow } from '../store/data';
-import { isObservable, notify } from '../helper/observable';
-import { setValue } from './data';
+import { setValue, makeObservable } from './data';
 import { isUndefined } from '../helper/common';
-import { createTreeRawRow } from '../store/helper/tree';
 import { isHiddenColumn } from '../query/column';
-
-function makeObservable(store: Store, rowKey: RowKey) {
-  const { data, column, id } = store;
-  const { rawData, viewData } = data;
-  const { columnMapWithRelation, treeColumnName, treeIcon } = column;
-  const foundIndex = findIndexByRowKey(data, column, id, rowKey, false);
-  const rawRow = rawData[foundIndex];
-
-  if (isObservable(rawRow)) {
-    return;
-  }
-
-  if (treeColumnName) {
-    const parentRow = findRowByRowKey(data, column, id, rawRow._attributes.tree!.parentRowKey);
-    rawData[foundIndex] = createTreeRawRow(rawRow, parentRow || null, columnMapWithRelation);
-    viewData[foundIndex] = createViewRow(
-      rawData[foundIndex],
-      columnMapWithRelation,
-      rawData,
-      treeColumnName,
-      treeIcon
-    );
-  } else {
-    rawData[foundIndex] = createRawRow(rawRow, foundIndex, columnMapWithRelation);
-    viewData[foundIndex] = createViewRow(rawData[foundIndex], columnMapWithRelation, rawData);
-  }
-  notify(data, 'rawData');
-  notify(data, 'viewData');
-}
 
 export function startEditing(store: Store, rowKey: RowKey, columnName: string) {
   const { data, focus, column, id } = store;

--- a/packages/toast-ui.grid/src/dispatch/sort.ts
+++ b/packages/toast-ui.grid/src/dispatch/sort.ts
@@ -9,6 +9,7 @@ import { isSortable, isInitialSortState, isScrollPagination } from '../query/dat
 import { isComplexHeader } from '../query/column';
 
 function sortData(store: Store) {
+  // @TODO: find more practical way to make observable
   // makes all data observable to sort the data properly;
   createObservableData(store, true);
   const { data, id } = store;

--- a/packages/toast-ui.grid/src/grid.tsx
+++ b/packages/toast-ui.grid/src/grid.tsx
@@ -696,9 +696,10 @@ export default class Grid {
    * @param {number|string} rowKey - The unique key of the row
    * @param {string} columnName - The name of the column
    * @param {number|string} value - The value to be set
+   * @param {boolean} [checkCellState=false] - If set to true, only editable and not disabled cells will be affected.
    */
-  public setValue(rowKey: RowKey, columnName: string, value: CellValue) {
-    this.dispatch('setValue', rowKey, columnName, value);
+  public setValue(rowKey: RowKey, columnName: string, value: CellValue, checkCellState?: boolean) {
+    this.dispatch('setValue', rowKey, columnName, value, checkCellState);
   }
 
   /**

--- a/packages/toast-ui.grid/src/grid.tsx
+++ b/packages/toast-ui.grid/src/grid.tsx
@@ -722,7 +722,7 @@ export default class Grid {
    * Set the all values in the specified column.
    * @param {string} columnName - The name of the column
    * @param {number|string} columnValue - The value to be set
-   * @param {boolean} [checkCellState=true] - If set to true, only editable and not disabled cells will be affected.
+   * @param {boolean} [checkCellState=false] - If set to true, only editable and not disabled cells will be affected.
    */
   public setColumnValues(columnName: string, columnValue: CellValue, checkCellState?: boolean) {
     this.dispatch('setColumnValues', columnName, columnValue, checkCellState);

--- a/packages/toast-ui.grid/src/query/validation.ts
+++ b/packages/toast-ui.grid/src/query/validation.ts
@@ -2,7 +2,7 @@ import { Store, InvalidRow } from '../store/types';
 import { createObservableData } from '../dispatch/data';
 
 export function getInvalidRows(store: Store) {
-  // makes all data observable to sort the data properly;
+  // @TODO: find more practical way to make observable
   createObservableData(store, true);
 
   const { data, column } = store;


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* checked cell state(`disabled`, `editable`) in `setColumnValues` API
  ```js
  targetRow[columnName] !== value && (!checkCellState || (!disabled && editable))
  ```

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
