### PR TITLE
fix: Error when calling "refreshRowHeight"

### DIFF
--- a/packages/toast-ui.grid/src/dispatch/renderState.ts
+++ b/packages/toast-ui.grid/src/dispatch/renderState.ts
@@ -3,6 +3,7 @@ import { RowKey } from '@t/store/data';
 import { PagePosition } from '@t/store/selection';
 import { notify } from '../helper/observable';
 import { findRowIndexByPosition } from '../query/mouse';
+import { isUndefined } from '../helper/common';
 
 export function setHoveredRowKey({ renderState }: Store, rowKey: RowKey | null) {
   renderState.hoveredRowKey = rowKey;
@@ -44,6 +45,11 @@ export function refreshRowHeight(store: Store, rowIndex: number, rowHeight: numb
   const { data, rowCoords, renderState } = store;
   const { cellHeightMap } = renderState;
   const cellHeights = cellHeightMap[rowIndex];
+
+  if (isUndefined(cellHeights)) {
+    return;
+  }
+
   const highestHeight = Object.keys(cellHeights).reduce(
     (acc, columnName) => Math.max(acc, cellHeights[columnName]),
     -1


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
Error when calling `refreshRowHeight` when `rowHeight` is `auto`
[`cellHeightMap`](https://github.com/nhn/tui.grid/blob/41b70cc9433f18d7bf7bd3da4d52238c64d57c12/packages/toast-ui.grid/src/dispatch/renderState.ts#L45) manages only the values ​​of visible rows.
but, [`refreshRowHeight`](https://github.com/nhn/tui.grid/blob/41b70cc9433f18d7bf7bd3da4d52238c64d57c12/packages/toast-ui.grid/src/dispatch/renderState.ts#L43) method is called for the entire row.
therefore, an error occurs because the [`cellHeights`](https://github.com/nhn/tui.grid/blob/41b70cc9433f18d7bf7bd3da4d52238c64d57c12/packages/toast-ui.grid/src/dispatch/renderState.ts#L46) value undefined.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
