### PR TITLE
feat: permit showing pagination on top of grid with pageOptions.position=top

### DIFF
--- a/packages/toast-ui.grid/src/store/data.ts
+++ b/packages/toast-ui.grid/src/store/data.ts
@@ -557,6 +557,7 @@ export function create({
         page: 1,
         perPage: 20,
         type: 'pagination',
+        position: 'bottom',
         ...userPageOptions,
         totalCount: userPageOptions.useClient ? rawData.length : userPageOptions.totalCount!
       };

--- a/packages/toast-ui.grid/src/view/container.tsx
+++ b/packages/toast-ui.grid/src/view/container.tsx
@@ -1,7 +1,7 @@
 import { h, Component } from 'preact';
 import { EditingEvent } from '@t/store/focus';
 import { SummaryPosition } from '@t/store/summary';
-import { ViewRow } from '@t/store/data';
+import { ViewRow, PageOptions } from '@t/store/data';
 import { RenderState } from '@t/store/renderState';
 import { LeftSide } from './leftSide';
 import { RightSide } from './rightSide';
@@ -37,6 +37,7 @@ interface StoreProps {
   summaryPosition: SummaryPosition;
   showLeftSide: boolean;
   viewData: ViewRow[];
+  pageOptions: PageOptions;
   eventBus: EventBus;
   scrollX: boolean;
   scrollY: boolean;
@@ -324,11 +325,11 @@ export class ContainerComp extends Component<Props> {
       scrollXHeight,
       showLeftSide,
       scrollX,
-      scrollY
+      scrollY,
+      pageOptions
     } = this.props;
     const style = { width: autoWidth ? '100%' : width };
     const attrs = { [dataAttr.GRID_ID]: gridId };
-
     return (
       <div
         {...attrs}
@@ -346,6 +347,7 @@ export class ContainerComp extends Component<Props> {
           this.el = el;
         }}
       >
+        {(!!pageOptions.position && pageOptions.position === 'top') && <Pagination />}
         <div
           class={cls(
             'content-area',
@@ -364,7 +366,7 @@ export class ContainerComp extends Component<Props> {
         {heightResizable && <HeightResizeHandle />}
         <StateLayer />
         <Clipboard />
-        <Pagination />
+        {(!pageOptions.position || pageOptions.position === 'bottom') && <Pagination />}
         <FilterLayer />
       </div>
     );
@@ -386,6 +388,7 @@ export const Container = connect<StoreProps, OwnProps>(
     showLeftSide: !!columnCoords.areaWidth.L,
     editingEvent: focus.editingEvent,
     viewData: data.viewData,
+    pageOptions: data.pageOptions,
     eventBus: getEventBus(id),
     scrollX: dimension.scrollX,
     scrollY: dimension.scrollY,

--- a/packages/toast-ui.grid/types/store/data.d.ts
+++ b/packages/toast-ui.grid/types/store/data.d.ts
@@ -104,6 +104,7 @@ export interface PageOptions {
   page?: number;
   totalCount?: number;
   type?: 'scroll' | 'pagination';
+  position?: 'top' | 'bottom';
 }
 
 export interface InvalidRow {


### PR DESCRIPTION
- I couldn't find develop branch so I branched off master
- it's a feature
- I think it follows your guidelines
- I did not add Tests nor Documentation changes. I would like to understand if this feature is interesting enough to be accepted or not before investing that time
- It is not a breaking change

### Description

This change permits the developer to add a `position` property to the grid Pagination option to indicate if they want to have the pagination widget above or below the grid.

```
       pageOptions: {
         useClient: true,
         perPage: 5,
         position: 'bottom'
       }
```

```
       pageOptions: {
         useClient: true,
         perPage: 5,
         position: 'top'
       }
```

By default, if no position property is given the pagination will appear below as it does currently