### PR TITLE
fix: pause observation when calling validatorFn internally

### DIFF
--- a/packages/toast-ui.grid/src/helper/observable.ts
+++ b/packages/toast-ui.grid/src/helper/observable.ts
@@ -35,6 +35,8 @@ let observerIdMap: Dictionary<boolean> = {};
 
 let pending = false;
 
+let paused = false;
+
 function batchUpdate(observerId: string) {
   if (!observerIdMap[observerId]) {
     observerIdMap[observerId] = true;
@@ -132,7 +134,7 @@ function makeObservableData<T extends Dictionary<any>>(
     enumerable: true,
     get() {
       const observerId = last(observerIdStack);
-      if (observerId && !observerIdSet[observerId]) {
+      if (!paused && observerId && !observerIdSet[observerId]) {
         observerIdSet[observerId] = true;
         observerInfoMap[observerId].targetObserverIdSets.push(observerIdSet);
       }
@@ -217,4 +219,12 @@ export function getOriginObject<T>(obj: Observable<T>) {
   }, obj.__storage__);
 
   return isEmpty(result) ? obj : result;
+}
+
+export function pauseObservation() {
+  paused = true;
+}
+
+export function continueObservation() {
+  paused = false;
 }

--- a/packages/toast-ui.grid/src/helper/observable.ts
+++ b/packages/toast-ui.grid/src/helper/observable.ts
@@ -221,10 +221,8 @@ export function getOriginObject<T>(obj: Observable<T>) {
   return isEmpty(result) ? obj : result;
 }
 
-export function pauseObservation() {
+export function unobservedInvoke(fn: Function) {
   paused = true;
-}
-
-export function continueObservation() {
+  fn();
   paused = false;
 }

--- a/packages/toast-ui.grid/src/store/data.ts
+++ b/packages/toast-ui.grid/src/store/data.ts
@@ -24,7 +24,14 @@ import {
 import { Filter } from '@t/store/filterLayerState';
 import { OptRow, Dictionary } from '@t/options';
 import { Range } from '@t/store/selection';
-import { observable, observe, Observable, getOriginObject } from '../helper/observable';
+import {
+  observable,
+  observe,
+  Observable,
+  getOriginObject,
+  pauseObservation,
+  continueObservation
+} from '../helper/observable';
 import { isRowHeader, isRowNumColumn, isCheckboxColumn } from '../helper/column';
 import {
   someProp,
@@ -157,9 +164,11 @@ function getValidationCode(
       '_relationListItemMap',
       '_disabledPriority'
     ) as Row;
+    pauseObservation();
     if (!validatorFn(value, originRow, columnName)) {
       invalidStates.push('VALIDATOR_FN');
     }
+    continueObservation();
   }
 
   if (dataType === 'string' && !isString(value)) {

--- a/packages/toast-ui.grid/src/store/data.ts
+++ b/packages/toast-ui.grid/src/store/data.ts
@@ -29,8 +29,7 @@ import {
   observe,
   Observable,
   getOriginObject,
-  pauseObservation,
-  continueObservation
+  unobservedInvoke
 } from '../helper/observable';
 import { isRowHeader, isRowNumColumn, isCheckboxColumn } from '../helper/column';
 import {
@@ -164,11 +163,12 @@ function getValidationCode(
       '_relationListItemMap',
       '_disabledPriority'
     ) as Row;
-    pauseObservation();
-    if (!validatorFn(value, originRow, columnName)) {
-      invalidStates.push('VALIDATOR_FN');
-    }
-    continueObservation();
+
+    unobservedInvoke(() => {
+      if (!validatorFn(value, originRow, columnName)) {
+        invalidStates.push('VALIDATOR_FN');
+      }
+    });
   }
 
   if (dataType === 'string' && !isString(value)) {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* paused observation when calling validatorFn internally for preventing to register unnecessary observer


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
