### PR TITLE
chore: make optional column infos optional in type

### DIFF
--- a/packages/toast-ui.grid/src/dispatch/column.ts
+++ b/packages/toast-ui.grid/src/dispatch/column.ts
@@ -35,7 +35,11 @@ function getCellWidthToBeResized(
   for (let idx = 0; idx < rangeLength; idx += 1) {
     const columnIdx = startIdx + idx;
     const { minWidth } = columns[columnIdx];
-    const width = Math.max(startWidths[idx] + delta, minWidth);
+
+    let width = startWidths[idx] + delta;
+    if (minWidth) {
+      width = Math.max(width, minWidth);
+    }
     widths.push(width);
   }
 

--- a/packages/toast-ui.grid/src/store/columnCoords.ts
+++ b/packages/toast-ui.grid/src/store/columnCoords.ts
@@ -2,7 +2,7 @@ import { ColumnInfo, Column } from '@t/store/column';
 import { Dimension } from '@t/store/dimension';
 import { ColumnCoords } from '@t/store/columnCoords';
 import { observable } from '../helper/observable';
-import { sum, findIndexes, pipe, mapProp, last } from '../helper/common';
+import { sum, findIndexes, pipe, last } from '../helper/common';
 
 function distributeExtraWidthEqually(extraWidth: number, targetIdxes: number[], widths: number[]) {
   const targetLen = targetIdxes.length;
@@ -86,8 +86,8 @@ function adjustWidths(
 
 function calculateWidths(columns: ColumnInfo[], cellBorderWidth: number, contentsWidth: number) {
   const baseWidths = columns.map(({ baseWidth }) => (baseWidth ? baseWidth - cellBorderWidth : 0));
-  const minWidths = columns.map(({ minWidth }) => minWidth - cellBorderWidth);
-  const fixedFlags = mapProp('fixedWidth', columns);
+  const minWidths = columns.map(({ minWidth }) => (minWidth ? minWidth - cellBorderWidth : 0));
+  const fixedFlags = columns.map(({ fixedWidth }) => fixedWidth ?? false);
 
   return pipe(
     baseWidths,

--- a/packages/toast-ui.grid/src/view/bodyCell.tsx
+++ b/packages/toast-ui.grid/src/view/bodyCell.tsx
@@ -41,18 +41,20 @@ export class BodyCellComp extends Component<Props> {
   public componentDidMount() {
     const { grid, rowKey, renderData, columnInfo } = this.props;
 
-    // eslint-disable-next-line new-cap
-    this.renderer = new columnInfo.renderer.type({
-      grid,
-      rowKey,
-      columnInfo,
-      ...renderData
-    });
-    const rendererEl = this.renderer.getElement();
-    this.el.appendChild(rendererEl);
+    if (columnInfo.renderer) {
+      // eslint-disable-next-line new-cap
+      this.renderer = new columnInfo.renderer.type({
+        grid,
+        rowKey,
+        columnInfo,
+        ...renderData
+      });
+      const rendererEl = this.renderer.getElement();
+      this.el.appendChild(rendererEl);
 
-    if (this.renderer.mounted) {
-      this.renderer.mounted(this.el);
+      if (this.renderer.mounted) {
+        this.renderer.mounted(this.el);
+      }
     }
     this.calculateRowHeight(this.props);
   }

--- a/packages/toast-ui.grid/types/store/column.d.ts
+++ b/packages/toast-ui.grid/types/store/column.d.ts
@@ -108,10 +108,10 @@ export interface InvalidColumn {
 
 export interface CommonColumnInfo {
   header: string;
-  hidden: boolean;
-  align: AlignType;
-  valign: VAlignType;
-  minWidth: number;
+  hidden?: boolean;
+  align?: AlignType;
+  valign?: VAlignType;
+  minWidth?: number;
   whiteSpace?: 'pre' | 'normal' | 'nowrap' | 'pre-wrap' | 'pre-line';
   ellipsis?: boolean;
   sortable?: boolean;
@@ -131,11 +131,11 @@ export interface CommonColumnInfo {
 
 export interface ColumnInfo extends CommonColumnInfo {
   readonly name: string;
-  headerAlign: AlignType;
-  headerVAlign: VAlignType;
-  baseWidth: number;
-  fixedWidth: boolean;
-  renderer: CellRendererOptions;
+  headerAlign?: AlignType;
+  headerVAlign?: VAlignType;
+  baseWidth?: number;
+  fixedWidth?: boolean;
+  renderer?: CellRendererOptions;
   editor?: CellEditorOptions;
   relationMap?: Dictionary<Relations>;
   related?: boolean;


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description
Some column infos keys were mandatory in the type definition.
As shown on the docs and examples, those are not mandatory and should have default values:
http://nhn.github.io/tui.grid/latest/Grid
http://nhn.github.io/tui.grid/latest/tutorial-example01-basic