### PR TITLE
fix: make the timing of calling validatorFn lazy

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/dataSource.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/dataSource.spec.ts
@@ -449,29 +449,30 @@ describe('request()', () => {
 
 describe('custom request event', () => {
   beforeEach(() => {
-    createGrid();
+    createGrid({
+      api: {
+        readData: { url: () => '/api/read', method: 'GET' }
+      },
+      initialRequest: false
+    });
   });
 
   it('xhr instance is included as custom event parameter', () => {
     const onBeforeRequest = cy.stub();
     const onResponse = cy.stub();
-    const onSuccessResponse = cy.stub();
 
     cy.gridInstance().invoke('on', 'beforeRequest', onBeforeRequest);
     cy.gridInstance().invoke('on', 'response', onResponse);
-    cy.gridInstance().invoke('on', 'successResponse', onSuccessResponse);
 
-    setTimeout(() => {
-      cy.wait('@readPage1');
+    cy.gridInstance().invoke('readData', 1);
+    cy.wait('@readPage1');
 
-      const xhr = {
-        url: 'http://localhost:8000/api/read?perPage=10&page=1'
-      };
+    const xhr = {
+      url: 'http://localhost:8000/api/read?perPage=10&page=1'
+    };
 
-      cy.wrap(onBeforeRequest).should('be.calledWithMatch', { xhr });
-      cy.wrap(onResponse).should('be.calledWithMatch', { xhr });
-      cy.wrap(onSuccessResponse).should('be.calledWithMatch', { xhr });
-    });
+    cy.wrap(onBeforeRequest).should('be.calledWithMatch', { xhr });
+    cy.wrap(onResponse).should('be.calledWithMatch', { xhr });
   });
 });
 

--- a/packages/toast-ui.grid/cypress/integration/validation.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/validation.spec.ts
@@ -138,7 +138,6 @@ describe('should check the validation of cell - validatorFn', () => {
   it('should execute `validatorFn` as unobserved function', () => {
     const stub = cy.stub();
     cy.window().then((win: WindowWithGrid) => {
-      delete win.grid;
       cy.createGrid({
         data,
         columns: [
@@ -164,7 +163,6 @@ describe('should check the validation of cell - validatorFn', () => {
   it('should execute `validatorFn` with applying changed data', () => {
     const stub = cy.stub();
     cy.window().then((win: WindowWithGrid) => {
-      delete win.grid;
       cy.createGrid({
         data,
         columns: [

--- a/packages/toast-ui.grid/cypress/integration/validation.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/validation.spec.ts
@@ -117,7 +117,7 @@ describe('should check the validation of cell - validatorFn', () => {
   });
 
   it('`value`, `row`, `columnName` should be passed as the parameters of validatorFn ', () => {
-    const callback = cy.stub();
+    const stub = cy.stub();
 
     cy.createGrid({
       data,
@@ -125,14 +125,14 @@ describe('should check the validation of cell - validatorFn', () => {
         {
           name: 'name',
           validation: {
-            validatorFn: callback
+            validatorFn: stub
           }
         }
       ]
     });
 
-    cy.wrap(callback).should('be.calledWithMatch', 'note', { rowKey: 0, name: 'note' }, 'name');
-    cy.wrap(callback).should('be.calledWithMatch', 'pen', { rowKey: 1, name: 'pen' }, 'name');
+    cy.wrap(stub).should('be.calledWithMatch', 'note', { rowKey: 0, name: 'note' }, 'name');
+    cy.wrap(stub).should('be.calledWithMatch', 'pen', { rowKey: 1, name: 'pen' }, 'name');
   });
 
   it('should execute `validatorFn` as unobserved function', () => {
@@ -147,7 +147,6 @@ describe('should check the validation of cell - validatorFn', () => {
             validation: {
               validatorFn: () => {
                 if (win.grid) {
-                  win.grid.getData();
                   stub();
                 }
               }
@@ -159,6 +158,36 @@ describe('should check the validation of cell - validatorFn', () => {
       cy.gridInstance().invoke('appendRow', {});
 
       cy.wrap(stub).should('be.calledOnce');
+    });
+  });
+
+  it('should execute `validatorFn` with applying changed data', () => {
+    const stub = cy.stub();
+    cy.window().then((win: WindowWithGrid) => {
+      delete win.grid;
+      cy.createGrid({
+        data,
+        columns: [
+          {
+            name: 'name',
+            validation: {
+              validatorFn: () => {
+                if (win.grid) {
+                  stub(win.grid.getColumnValues('name'));
+                }
+              }
+            }
+          }
+        ]
+      });
+
+      cy.gridInstance().invoke('appendRow', { name: 'pencil', price: 100 });
+
+      cy.wrap(stub).should('be.calledWithMatch', ['note', 'pen', 'pencil']);
+
+      cy.gridInstance().invoke('setRow', 0, { name: 'eraser', price: 2000 });
+
+      cy.wrap(stub).should('be.calledWithMatch', ['eraser', 'pen', 'pencil']);
     });
   });
 });

--- a/packages/toast-ui.grid/cypress/support/commands.js
+++ b/packages/toast-ui.grid/cypress/support/commands.js
@@ -117,3 +117,9 @@ Cypress.Commands.add('focusAndWait', (rowKey, columnName) => {
   cy.gridInstance().invoke('focus', rowKey, columnName);
   cy.wait(100);
 });
+
+Cypress.Commands.add('destroyGrid', () => {
+  return cy.window().then(win => {
+    delete win.grid;
+  });
+});

--- a/packages/toast-ui.grid/cypress/support/index.d.ts
+++ b/packages/toast-ui.grid/cypress/support/index.d.ts
@@ -41,6 +41,8 @@ declare namespace Cypress {
     getBodyCells(): Chainable<any>;
 
     focusAndWait(rowKey: RowKey, columnName: string): Chainable<any>;
+
+    destroyGrid(): Chainable<any>;
   }
 }
 

--- a/packages/toast-ui.grid/cypress/support/index.js
+++ b/packages/toast-ui.grid/cypress/support/index.js
@@ -19,6 +19,10 @@ import './commands';
 import { isSubsetOf } from '../helper/compare';
 import { cls } from '@/helper/dom';
 
+afterEach(() => {
+  cy.destroyGrid();
+});
+
 chai.use(_chai => {
   _chai.Assertion.addMethod('subset', function(options) {
     new _chai.Assertion(isSubsetOf(options, this._obj)).to.be.true;

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -21,7 +21,8 @@ import {
   someProp,
   findPropIndex,
   shallowEqual,
-  isUndefined
+  isUndefined,
+  splice
 } from '../helper/common';
 import { OptRow, OptAppendRow, OptRemoveRow } from '@t/options';
 import {
@@ -66,8 +67,6 @@ import { initFilter } from './filter';
 import { getSelectionRange } from '../query/selection';
 import { initScrollPosition } from './viewport';
 import { isRowHeader } from '../helper/column';
-
-const protoSplice = Array.prototype.splice;
 
 function updateRowSpanWhenAppend(data: Row[], prevRow: Row, extendPrevRowSpan: boolean) {
   const { rowSpanMap: prevRowSpanMap } = prevRow;
@@ -576,8 +575,8 @@ export function appendRow(store: Store, row: OptRow, options: OptAppendRow) {
   const { at = rawData.length } = options;
   const { rawRow, viewRow, prevRow } = getCreatedRowInfo(store, at, row);
 
-  protoSplice.call(viewData, at, 0, viewRow);
-  protoSplice.call(rawData, at, 0, rawRow);
+  splice(viewData, at, 0, viewRow);
+  splice(rawData, at, 0, rawRow);
   makeObservable(store, at);
   updatePageOptions(store, { totalCount: pageOptions.totalCount! + 1 });
   updateHeights(store);
@@ -950,8 +949,8 @@ export function setRow(store: Store, rowIndex: number, row: OptRow) {
   row.sortKey = orgRow.sortKey;
   const { rawRow, viewRow, prevRow } = getCreatedRowInfo(store, rowIndex, row, orgRow.rowKey);
 
-  protoSplice.call(viewData, rowIndex, 1, viewRow);
-  protoSplice.call(rawData, rowIndex, 1, rawRow);
+  splice(viewData, rowIndex, 1, viewRow);
+  splice(rawData, rowIndex, 1, rawRow);
   makeObservable(store, rowIndex);
 
   sortByCurrentState(store);

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -190,11 +190,11 @@ export function updatePageOptions(
   }
 }
 
-export function makeObservable(store: Store, index: number) {
+export function makeObservable(store: Store, rowIndex: number) {
   const { data, column, id } = store;
   const { rawData, viewData } = data;
   const { columnMapWithRelation, treeColumnName, treeIcon } = column;
-  const rawRow = rawData[index];
+  const rawRow = rawData[rowIndex];
 
   if (isObservable(rawRow)) {
     return;
@@ -202,17 +202,17 @@ export function makeObservable(store: Store, index: number) {
 
   if (treeColumnName) {
     const parentRow = findRowByRowKey(data, column, id, rawRow._attributes.tree!.parentRowKey);
-    rawData[index] = createTreeRawRow(rawRow, parentRow || null, columnMapWithRelation);
-    viewData[index] = createViewRow(
-      rawData[index],
+    rawData[rowIndex] = createTreeRawRow(rawRow, parentRow || null, columnMapWithRelation);
+    viewData[rowIndex] = createViewRow(
+      rawData[rowIndex],
       columnMapWithRelation,
       rawData,
       treeColumnName,
       treeIcon
     );
   } else {
-    rawData[index] = createRawRow(rawRow, index, columnMapWithRelation);
-    viewData[index] = createViewRow(rawData[index], columnMapWithRelation, rawData);
+    rawData[rowIndex] = createRawRow(rawRow, rowIndex, columnMapWithRelation);
+    viewData[rowIndex] = createViewRow(rawData[rowIndex], columnMapWithRelation, rawData);
   }
   notify(data, 'rawData', 'filteredRawData', 'viewData', 'filteredViewData');
 }

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -22,7 +22,7 @@ import {
   findPropIndex,
   shallowEqual,
   isUndefined,
-  splice
+  silentSplice
 } from '../helper/common';
 import { OptRow, OptAppendRow, OptRemoveRow } from '@t/options';
 import {
@@ -575,8 +575,8 @@ export function appendRow(store: Store, row: OptRow, options: OptAppendRow) {
   const { at = rawData.length } = options;
   const { rawRow, viewRow, prevRow } = getCreatedRowInfo(store, at, row);
 
-  splice(viewData, at, 0, viewRow);
-  splice(rawData, at, 0, rawRow);
+  silentSplice(viewData, at, 0, viewRow);
+  silentSplice(rawData, at, 0, rawRow);
   makeObservable(store, at);
   updatePageOptions(store, { totalCount: pageOptions.totalCount! + 1 });
   updateHeights(store);
@@ -949,8 +949,8 @@ export function setRow(store: Store, rowIndex: number, row: OptRow) {
   row.sortKey = orgRow.sortKey;
   const { rawRow, viewRow, prevRow } = getCreatedRowInfo(store, rowIndex, row, orgRow.rowKey);
 
-  splice(viewData, rowIndex, 1, viewRow);
-  splice(rawData, rowIndex, 1, rawRow);
+  silentSplice(viewData, rowIndex, 1, viewRow);
+  silentSplice(rawData, rowIndex, 1, rawRow);
   makeObservable(store, rowIndex);
 
   sortByCurrentState(store);

--- a/packages/toast-ui.grid/src/dispatch/focus.ts
+++ b/packages/toast-ui.grid/src/dispatch/focus.ts
@@ -19,7 +19,7 @@ export function startEditing(store: Store, rowKey: RowKey, columnName: string) {
   }
 
   // makes the data observable to judge editable, disable of the cell;
-  makeObservable(store, rowKey);
+  makeObservable(store, findIndexByRowKey(data, column, id, rowKey, false));
 
   if (!isEditableCell(data, column, foundIndex, columnName)) {
     return;
@@ -141,7 +141,7 @@ export function saveAndFinishEditing(store: Store, value?: string) {
   // @TODO: remove 'value' paramter
   // saveAndFinishEditing(store: Store)
 
-  const { focus } = store;
+  const { focus, data, column, id } = store;
   const { editingAddress } = focus;
 
   if (!editingAddress) {
@@ -151,7 +151,7 @@ export function saveAndFinishEditing(store: Store, value?: string) {
   const { rowKey, columnName } = editingAddress;
 
   // makes the data observable to judge editable, disable of the cell.
-  makeObservable(store, rowKey);
+  makeObservable(store, findIndexByRowKey(data, column, id, rowKey, false));
 
   // if value is 'undefined', editing result is saved and finished.
   if (isUndefined(value)) {

--- a/packages/toast-ui.grid/src/helper/common.ts
+++ b/packages/toast-ui.grid/src/helper/common.ts
@@ -420,3 +420,7 @@ export function convertTextToData(text: string) {
     )
   );
 }
+
+export function splice<T>(arr: T[], start: number, deleteCount: number, ...items: T[]): T[] {
+  return Array.prototype.splice.call(arr, start, deleteCount, ...items);
+}

--- a/packages/toast-ui.grid/src/helper/common.ts
+++ b/packages/toast-ui.grid/src/helper/common.ts
@@ -421,6 +421,6 @@ export function convertTextToData(text: string) {
   );
 }
 
-export function splice<T>(arr: T[], start: number, deleteCount: number, ...items: T[]): T[] {
+export function silentSplice<T>(arr: T[], start: number, deleteCount: number, ...items: T[]): T[] {
   return Array.prototype.splice.call(arr, start, deleteCount, ...items);
 }

--- a/packages/toast-ui.grid/src/query/data.ts
+++ b/packages/toast-ui.grid/src/query/data.ts
@@ -1,6 +1,6 @@
 import { OptRow, Dictionary } from '@t/options';
 import { Store } from '@t/store';
-import { Data, Row, RowKey, SortState, RawRowOptions, ViewRow } from '@t/store/data';
+import { Data, Row, RowKey, SortState } from '@t/store/data';
 import { Column } from '@t/store/column';
 import {
   isFunction,

--- a/packages/toast-ui.grid/src/query/data.ts
+++ b/packages/toast-ui.grid/src/query/data.ts
@@ -197,7 +197,7 @@ export function getCreatedRowInfo(store: Store, rowIndex: number, row: OptRow, r
   const { rawData } = data;
   const { columnMapWithRelation, allColumns } = column;
   const prevRow = rawData[rowIndex - 1];
-  const options: RawRowOptions = { prevRow, lazyObservable: true };
+  const options = { prevRow, lazyObservable: true };
 
   if (!isUndefined(rowKey)) {
     row.rowKey = rowKey;
@@ -208,7 +208,7 @@ export function getCreatedRowInfo(store: Store, rowIndex: number, row: OptRow, r
     .reduce((acc, { name }) => ({ ...acc, [name]: '' }), {});
   const index = getMaxRowKey(data);
   const rawRow = createRawRow({ ...emptyData, ...row }, index, columnMapWithRelation, options);
-  const viewRow = { rowKey: row.rowKey, sortKey: row.sortKey, uniqueKey: row.uniqueKey } as ViewRow;
+  const viewRow = { rowKey: row.rowKey, sortKey: row.sortKey, uniqueKey: row.uniqueKey };
 
   return { rawRow, viewRow, prevRow };
 }

--- a/packages/toast-ui.grid/src/query/data.ts
+++ b/packages/toast-ui.grid/src/query/data.ts
@@ -1,6 +1,6 @@
 import { OptRow, Dictionary } from '@t/options';
 import { Store } from '@t/store';
-import { Data, Row, RowKey, SortState, RawRowOptions } from '@t/store/data';
+import { Data, Row, RowKey, SortState, RawRowOptions, ViewRow } from '@t/store/data';
 import { Column } from '@t/store/column';
 import {
   isFunction,
@@ -18,12 +18,7 @@ import { getDataManager } from '../instance';
 import { isRowSpanEnabled } from './rowSpan';
 import { isHiddenColumn } from './column';
 import { isRowHeader } from '../helper/column';
-import {
-  createRawRow,
-  createViewRow,
-  generateDataCreationKey,
-  getFormattedValue
-} from '../store/data';
+import { createRawRow, generateDataCreationKey, getFormattedValue } from '../store/data';
 
 export function getCellAddressByIndex(
   { data, column }: Store,
@@ -202,7 +197,7 @@ export function getCreatedRowInfo(store: Store, rowIndex: number, row: OptRow, r
   const { rawData } = data;
   const { columnMapWithRelation, allColumns } = column;
   const prevRow = rawData[rowIndex - 1];
-  const options: RawRowOptions = { prevRow };
+  const options: RawRowOptions = { prevRow, lazyObservable: true };
 
   if (!isUndefined(rowKey)) {
     row.rowKey = rowKey;
@@ -213,7 +208,7 @@ export function getCreatedRowInfo(store: Store, rowIndex: number, row: OptRow, r
     .reduce((acc, { name }) => ({ ...acc, [name]: '' }), {});
   const index = getMaxRowKey(data);
   const rawRow = createRawRow({ ...emptyData, ...row }, index, columnMapWithRelation, options);
-  const viewRow = createViewRow(rawRow, columnMapWithRelation, rawData);
+  const viewRow = { rowKey: row.rowKey, sortKey: row.sortKey, uniqueKey: row.uniqueKey } as ViewRow;
 
   return { rawRow, viewRow, prevRow };
 }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* The timing of calling `validatorFn` is made lazy when calling `appendRow`, `setRow` to apply changed data


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
