### PR TITLE
feat: getFormattedValue API

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/data.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/data.spec.ts
@@ -1,6 +1,11 @@
 import { OptGrid } from '@t/options';
 import { Row } from '@t/store/data';
 import { cls } from '@/helper/dom';
+import { FormatterProps } from '@t/store/column';
+
+function invokeFilter(columnName: string, states: any) {
+  cy.gridInstance().invoke('filter', columnName, states);
+}
 
 function applyAliasHeaderCheckbox() {
   cy.getByCls('cell-row-header')
@@ -318,7 +323,7 @@ describe('removeRow()', () => {
       .should('eql', { rowKey: null, columnName: null, value: null });
   });
 
-  it('should reduce the height after removing the row', () => {
+  it('should reduce the height after removing the row', () => {
     createGrid({ bodyHeight: 50, minBodyHeight: 50 });
 
     cy.getByCls('body-container')
@@ -849,5 +854,81 @@ it('should change the value of the hidden cell', () => {
     columnName: 'gender',
     value: 'male',
     prevValue: 'female'
+  });
+});
+
+describe('getValue()', () => {
+  beforeEach(() => {
+    const columns = [{ name: 'name', filter: 'text' }, { name: 'age' }];
+    // @ts-ignore
+    createGrid({ columns });
+  });
+
+  it('should get the value of the cell', () => {
+    cy.gridInstance()
+      .invoke('getValue', 0, 'name')
+      .should('eq', 'Kim');
+  });
+
+  it('should get the value of the filtered cell', () => {
+    invokeFilter('name', [{ code: 'eq', value: 'Lee' }]);
+
+    cy.gridInstance()
+      .invoke('getValue', 0, 'name')
+      .should('eq', 'Kim');
+  });
+
+  it('should return null when there is no matched rowKey ', () => {
+    cy.gridInstance()
+      .invoke('getValue', 3, 'name')
+      .should('eq', null);
+  });
+
+  it('should return null when there is no matched columnName ', () => {
+    cy.gridInstance()
+      .invoke('getValue', 0, 'none')
+      .should('eq', null);
+  });
+});
+
+describe('getFormattedValue()', () => {
+  beforeEach(() => {
+    const columns = [
+      {
+        name: 'name',
+        formatter({ value }: FormatterProps) {
+          return `formatted${value}`;
+        }
+      },
+      { name: 'age' }
+    ];
+    // @ts-ignore
+    createGrid({ columns });
+  });
+
+  it('should get the formatted value of the cell', () => {
+    cy.gridInstance()
+      .invoke('getFormattedValue', 0, 'name')
+      .should('eq', 'formattedKim');
+  });
+
+  it('should get the formatted value of the filtered cell', () => {
+    invokeFilter('name', [{ code: 'eq', value: 'Lee' }]);
+
+    cy.gridInstance()
+      .invoke('getFormattedValue', 0, 'name')
+      .should('eq', 'formattedKim');
+  });
+
+  it('should return null when there is no matched rowKey ', () => {
+    cy.gridInstance()
+      .invoke('getFormattedValue', 3, 'name')
+      .should('eq', null);
+  });
+
+  it('should return null when there is no matched columnName ', () => {
+    cy.gridInstance()
+      .invoke('getFormattedValue', 0, 'none')
+      .should('eq', null);
   });
 });

--- a/packages/toast-ui.grid/cypress/integration/lazyObservable.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/lazyObservable.spec.ts
@@ -46,7 +46,10 @@ before(() => {
 describe('should API is executed properly on lazy observable data', () => {
   beforeEach(() => {
     const columns = [
-      { name: 'name', editor: 'text' },
+      {
+        name: 'name',
+        editor: 'text'
+      },
       { name: 'artist', editor: 'text' },
       { name: 'type', editor: 'text' }
     ];
@@ -250,6 +253,12 @@ describe('should API is executed properly on lazy observable data', () => {
     cy.gridInstance()
       .invoke('getColumnValues', 'name')
       .should('eql', Array(20).fill('anonymous'));
+  });
+
+  it('getFormattedValue()', () => {
+    cy.gridInstance()
+      .invoke('getFormattedValue', 19, 'name')
+      .should('eq', 'Chaos And The Calm');
   });
 });
 

--- a/packages/toast-ui.grid/cypress/integration/lazyObservable.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/lazyObservable.spec.ts
@@ -46,10 +46,7 @@ before(() => {
 describe('should API is executed properly on lazy observable data', () => {
   beforeEach(() => {
     const columns = [
-      {
-        name: 'name',
-        editor: 'text'
-      },
+      { name: 'name', editor: 'text' },
       { name: 'artist', editor: 'text' },
       { name: 'type', editor: 'text' }
     ];

--- a/packages/toast-ui.grid/src/grid.tsx
+++ b/packages/toast-ui.grid/src/grid.tsx
@@ -51,7 +51,8 @@ import {
   findIndexByRowKey,
   findRowByRowKey,
   getFilterStateWithOperator,
-  getRowHeight
+  getRowHeight,
+  getFormattedValue
 } from './query/data';
 import { isRowHeader } from './helper/column';
 import { createProvider } from './dataSource/serverSideDataProvider';
@@ -717,10 +718,10 @@ export default class Grid implements TuiGrid {
    */
   public getValue(rowKey: RowKey, columnName: string): CellValue | null {
     const { data, column, id } = this.store;
-    const targetRow = findRowByRowKey(data, column, id, rowKey);
+    const targetRow = findRowByRowKey(data, column, id, rowKey, false);
 
     if (targetRow) {
-      return targetRow[columnName];
+      return targetRow[columnName] || null;
     }
 
     return null;
@@ -1626,5 +1627,15 @@ export default class Grid implements TuiGrid {
    */
   public appendRows(data: OptRow[]) {
     this.dispatch('appendRows', data);
+  }
+
+  /**
+   * Return the formatted value of the cell identified by the rowKey and columnName.
+   * @param {number|string} rowKey - The unique key of the target row.
+   * @param {string} columnName - The name of the column
+   * @returns {number|string|boolean|null} - The value of the cell
+   */
+  public getFormattedValue(rowKey: RowKey, columnName: string): string | null {
+    return getFormattedValue(this.store, rowKey, columnName);
   }
 }

--- a/packages/toast-ui.grid/src/query/data.ts
+++ b/packages/toast-ui.grid/src/query/data.ts
@@ -18,7 +18,12 @@ import { getDataManager } from '../instance';
 import { isRowSpanEnabled } from './rowSpan';
 import { isHiddenColumn } from './column';
 import { isRowHeader } from '../helper/column';
-import { createRawRow, generateDataCreationKey, getFormattedValue } from '../store/data';
+import {
+  createRawRow,
+  generateDataCreationKey,
+  getFormattedValue as formattedValue
+} from '../store/data';
+import { makeObservable } from '../dispatch/data';
 
 export function getCellAddressByIndex(
   { data, column }: Store,
@@ -145,7 +150,7 @@ export function getUniqColumnData(targetData: Row[], column: Column, columnName:
     };
     const relationListItems = row._relationListItemMap[columnName];
 
-    return getFormattedValue(formatterProps, columnInfo.formatter, value, relationListItems);
+    return formattedValue(formatterProps, columnInfo.formatter, value, relationListItems);
   });
 }
 
@@ -238,4 +243,17 @@ export function isClientPagination({ pageOptions }: Data) {
 
 export function getRowIndexWithPage(data: Data, rowIndex: number) {
   return isClientPagination(data) ? rowIndex % data.pageOptions.perPage : rowIndex;
+}
+
+export function getFormattedValue(store: Store, rowKey: RowKey, columnName: string) {
+  const { data, column, id } = store;
+  const rowIndex = findIndexByRowKey(data, column, id, rowKey, false);
+  const { viewData } = data;
+
+  if (rowIndex !== -1) {
+    makeObservable(store, rowIndex);
+    const viewCell = viewData[rowIndex].valueMap[columnName];
+    return viewCell ? viewCell.formattedValue : null;
+  }
+  return null;
 }

--- a/packages/toast-ui.grid/types/index.d.ts
+++ b/packages/toast-ui.grid/types/index.d.ts
@@ -261,6 +261,8 @@ declare namespace tui {
     public clearModifiedData(type?: ModificationTypeCode): void;
 
     public appendRows(data: OptRow[]): void;
+
+    public getFormattedValue(rowKey: RowKey, columnName: string): string | null;
   }
 }
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* added `getFormattedValue` API to get formatted value. 
  * `getFormattedValue(rowKey: RowKey, columnName: string): string`
  * The API is useful to below example
  ```js
   // ...
   {
       header: 'Grade',
       name: 'grade',
       formatter: 'listItemText',
   }
   // ...
   // get formatted value
   grid.getFormattedValue(0, 'grade')
   ```



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
