### PR TITLE
fix: change summary content after calling `setColumns` API

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/summary.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/summary.spec.ts
@@ -69,7 +69,7 @@ function assertSummaryContent(columnName: string, ...contents: string[]) {
 }
 
 function assertSummaryPosition(index: number, prevElClassName: string) {
-  cy.get(`.${cls('summary-area')}`)
+  cy.getByCls('summary-area')
     .eq(index)
     .prev()
     .should('have.class', prevElClassName);
@@ -82,11 +82,11 @@ function assertScrollLeft(alias: string, scrollLeft: number) {
 }
 
 function assertSyncScrollLeft(index: number) {
-  cy.get(`.${cls('body-area')}`)
+  cy.getByCls('body-area')
     .eq(index)
     .as('bodyArea');
 
-  cy.get(`.${cls('summary-area')}`)
+  cy.getByCls('summary-area')
     .eq(index)
     .as('summaryArea');
 
@@ -107,9 +107,7 @@ describe('summary', () => {
     const summary = createSummaryOption({ height: 0 });
     cy.createGrid({ ...defaultOptions, summary });
 
-    cy.get(`.${cls('container')}`).should($container => {
-      expect($container.find(`.${cls('summary-area')}`)).not.to.exist;
-    });
+    cy.getByCls('summary-area').should('not.be.visible');
   });
 
   context('calculation', () => {
@@ -156,13 +154,9 @@ describe('summary', () => {
       }));
       cy.createGrid({ ...options, columns });
 
-      cy.get(`.${cls('container')}`)
-        .trigger('mousedown')
-        .trigger('dblclick')
-        .within(() => {
-          cy.get(`.${cls('layer-editing')} input`).type('500000{enter}');
-          assertSummaryContent('price', 'MAX: 500000', 'MIN: 1');
-        });
+      cy.gridInstance().invoke('setValue', 1, 'price', 500000);
+
+      assertSummaryContent('price', 'MAX: 500000', 'MIN: 1');
     });
   });
 
@@ -227,7 +221,7 @@ describe('summary', () => {
       const columns = options.columns.map(column => ({ ...column, resizable: true }));
       cy.createGrid({ ...options, columns });
 
-      cy.get(`.${cls('column-resize-handle')}`)
+      cy.getByCls('column-resize-handle')
         .eq(0)
         .trigger('mousedown')
         .trigger('mousemove', { pageX: CONTENT_WIDTH })
@@ -237,39 +231,97 @@ describe('summary', () => {
     });
   });
 
-  it("change summary's value properly after call setSummaryColumnContent()", () => {
-    const defaultOptions = createDefaultOptions();
-    cy.createGrid(defaultOptions);
-    cy.gridInstance().invoke('setSummaryColumnContent', 'price', 'static content');
-    assertSummaryContent('price', 'static content');
+  context('setSummaryColumnContent API', () => {
+    it("change summary's value properly after changing existing summary column through setSummaryColumnContent()", () => {
+      const defaultOptions = createDefaultOptions();
+      cy.createGrid(defaultOptions);
+      cy.gridInstance().invoke('setSummaryColumnContent', 'price', 'static content');
+      assertSummaryContent('price', 'static content');
 
-    cy.gridInstance().invoke('setSummaryColumnContent', 'price', {
-      template(valueMap: SummaryValueMap) {
-        return `auto calculate: ${valueMap.max}`;
-      }
-    });
-    assertSummaryContent('price', 'auto calculate: 5');
+      cy.gridInstance().invoke('setSummaryColumnContent', 'price', {
+        template(valueMap: SummaryValueMap) {
+          return `auto calculate: ${valueMap.max}`;
+        }
+      });
+      assertSummaryContent('price', 'auto calculate: 5');
 
-    cy.gridInstance().invoke('setSummaryColumnContent', 'price', {
-      template(valueMap: SummaryValueMap) {
-        return `no auto calculate: ${valueMap.max}`;
-      },
-      useAutoSummary: false
+      cy.gridInstance().invoke('setSummaryColumnContent', 'price', {
+        template(valueMap: SummaryValueMap) {
+          return `no auto calculate: ${valueMap.max}`;
+        },
+        useAutoSummary: false
+      });
+      assertSummaryContent('price', 'no auto calculate: 0');
     });
-    assertSummaryContent('price', 'no auto calculate: 0');
 
-    cy.gridInstance().invoke('setSummaryColumnContent', 'name', {
-      template(valueMap: SummaryValueMap) {
-        return `auto calculate: ${valueMap.sum}`;
-      }
+    it("change summary's value properly after changing new summary column through setSummaryColumnContent()", () => {
+      const defaultOptions = createDefaultOptions();
+      cy.createGrid(defaultOptions);
+
+      cy.gridInstance().invoke('setSummaryColumnContent', 'name', {
+        template(valueMap: SummaryValueMap) {
+          return `auto calculate: ${valueMap.sum}`;
+        }
+      });
+      assertSummaryContent('name', 'auto calculate: 0');
     });
-    assertSummaryContent('name', 'auto calculate: 0');
-    assertSummaryContent('downloadCount', 'TOTAL: 15', 'AVG: 3.00');
+
+    it('summaryColumnContent is priority than defaultContent', () => {
+      const summary = {
+        height: 40,
+        defaultContent: {
+          template(valueMap: SummaryValueMap) {
+            return `DEFAULT_MAX: ${valueMap.max}<br>DEFAULT_MIN: ${valueMap.min}`;
+          }
+        }
+      };
+      const defaultOptions = createDefaultOptions();
+      cy.createGrid({ ...defaultOptions, summary });
+      cy.gridInstance().invoke('setSummaryColumnContent', 'price', {
+        template(valueMap: SummaryValueMap) {
+          return `auto calculate: ${valueMap.max}`;
+        }
+      });
+
+      assertSummaryContent('price', 'auto calculate: 5');
+    });
+
+    it('summaryColumnContent is applied after calling setColumns API', () => {
+      const defaultOptions = createDefaultOptions();
+      const columns = [
+        { name: 'name', minWidth: 150 },
+        { name: 'price', minWidth: 150 },
+        { name: 'downloadCount', minWidth: 150 }
+      ];
+      cy.createGrid({ ...defaultOptions, columns: [] });
+
+      cy.gridInstance().invoke('setColumns', columns);
+
+      assertSummaryContent('price', 'MAX: 5', 'MIN: 1');
+      assertSummaryContent('downloadCount', 'TOTAL: 15', 'AVG: 3.00');
+    });
+
+    it('summaryColumnContent is applied on maniplating the row after calling setColumns API', () => {
+      const defaultOptions = createDefaultOptions();
+      const columns = [
+        { name: 'name', minWidth: 150 },
+        { name: 'price', minWidth: 150 },
+        { name: 'downloadCount', minWidth: 150 }
+      ];
+      cy.createGrid({ ...defaultOptions, columns: [] });
+
+      cy.gridInstance().invoke('setColumns', columns);
+      cy.gridInstance().invoke('appendRow', { name: 'TOAST', price: 6, downloadCount: 3 });
+
+      assertSummaryContent('price', 'MAX: 6', 'MIN: 1');
+      assertSummaryContent('downloadCount', 'TOTAL: 18', 'AVG: 3.00');
+    });
   });
 
   it('return proper values when calls getSummaryValues() method', () => {
     const defaultOptions = createDefaultOptions();
     cy.createGrid(defaultOptions);
+
     cy.gridInstance()
       .invoke('getSummaryValues', 'price')
       .should('have.subset', {
@@ -405,33 +457,6 @@ describe('summary', () => {
         min: 1,
         sum: 15
       });
-    cy.gridInstance().invoke('setColumns', [
-      { name: 'name', minWidth: 150 },
-      { name: 'price', minWidth: 150 },
-      { name: 'downloadCount', minWidth: 150 }
-    ]);
-
-    assertSummaryContent('price', 'MAX: 5', 'MIN: 1');
-  });
-
-  it('summaryColumnContent is priority than defaultContent', () => {
-    const summary = {
-      height: 40,
-      defaultContent: {
-        template(valueMap: SummaryValueMap) {
-          return `DEFAULT_MAX: ${valueMap.max}<br>DEFAULT_MIN: ${valueMap.min}`;
-        }
-      }
-    };
-    const defaultOptions = createDefaultOptions();
-    cy.createGrid({ ...defaultOptions, summary });
-    cy.gridInstance().invoke('setSummaryColumnContent', 'price', {
-      template(valueMap: SummaryValueMap) {
-        return `auto calculate: ${valueMap.max}`;
-      }
-    });
-
-    assertSummaryContent('price', 'auto calculate: 5');
   });
 });
 

--- a/packages/toast-ui.grid/cypress/integration/summary.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/summary.spec.ts
@@ -301,7 +301,7 @@ describe('summary', () => {
       assertSummaryContent('downloadCount', 'TOTAL: 15', 'AVG: 3.00');
     });
 
-    it('summaryColumnContent is applied on maniplating the row after calling setColumns API', () => {
+    it('summaryColumnContent is applied on manipulating the row after calling setColumns API', () => {
       const defaultOptions = createDefaultOptions();
       const columns = [
         { name: 'name', minWidth: 150 },

--- a/packages/toast-ui.grid/src/dispatch/column.ts
+++ b/packages/toast-ui.grid/src/dispatch/column.ts
@@ -9,7 +9,6 @@ import { createViewRow, generateDataCreationKey } from '../store/data';
 import GridEvent from '../event/gridEvent';
 import { getEventBus } from '../event/eventBus';
 import { initFocus } from './focus';
-import { addColumnSummaryValues } from './summary';
 import { isObservable, notify, partialObservable } from '../helper/observable';
 import { unsort } from './sort';
 import { initFilter, unfilter } from './filter';
@@ -150,7 +149,6 @@ export function setColumns(store: Store, optColumns: OptColumn[]) {
 
   initFilter(store);
   unsort(store);
-  addColumnSummaryValues(store);
 }
 
 export function resetColumnWidths({ column }: Store, widths: number[]) {

--- a/packages/toast-ui.grid/src/dispatch/summary.ts
+++ b/packages/toast-ui.grid/src/dispatch/summary.ts
@@ -3,8 +3,9 @@ import { SummaryColumnContentMap } from '@t/store/summary';
 import { Row } from '@t/store/data';
 import { UpdateType, Options } from '@t/dispatch';
 import { castToSummaryColumnContent, extractSummaryColumnContent } from '../helper/summary';
-import { isEmpty, findProp, isFunction } from '../helper/common';
+import { findProp, isFunction } from '../helper/common';
 import { createSummaryValue } from '../store/summary';
+import { notify } from '../helper/observable';
 
 export function setSummaryColumnContent(
   { summary, data }: Store,
@@ -16,6 +17,8 @@ export function setSummaryColumnContent(
 
   summary.summaryColumnContents[columnName] = content;
   summary.summaryValues[columnName] = createSummaryValue(content, columnName, data);
+
+  notify(summary, 'summaryValues');
 }
 
 function updateSummaryValue(
@@ -110,6 +113,8 @@ function updateSummaryValue(
       cnt: filteredCnt
     }
   };
+
+  notify(summary, 'summaryValues');
 }
 
 export function updateSummaryValueByCell(store: Store, columnName: string, options: Options) {
@@ -147,21 +152,6 @@ export function updateAllSummaryValues({ summary, data, column }: Store) {
     const content = summary.summaryColumnContents[name];
     summary.summaryValues[name] = createSummaryValue(content, name, data);
   });
-}
 
-export function addColumnSummaryValues({ summary, data, column }: Store) {
-  if (!isEmpty(summary)) {
-    const { defaultContent } = summary;
-    const castedDefaultContent = castToSummaryColumnContent(defaultContent || '');
-
-    column.allColumns.forEach(({ name }) => {
-      const orgSummaryContent = summary.summaryColumnContents[name];
-      let content = orgSummaryContent;
-      if (!orgSummaryContent) {
-        content = extractSummaryColumnContent(null, castedDefaultContent);
-        summary.summaryColumnContents[name] = content;
-      }
-      summary.summaryValues[name] = createSummaryValue(content, name, data);
-    });
-  }
+  notify(summary, 'summaryValues');
 }

--- a/packages/toast-ui.grid/src/store/summary.ts
+++ b/packages/toast-ui.grid/src/store/summary.ts
@@ -54,11 +54,11 @@ export function create({ column, data, summary }: SummaryOption): Summary {
     const castedDefaultContent = castToSummaryColumnContent(defaultContent || '');
     const columnContent = orgColumnContent || {};
     const summaryColumns = Object.keys(columnContent);
-    const filteredSummaryColumns = Object.keys(columnContent).filter(
+    const filteredSummaryColumns = summaryColumns.filter(
       columnName => !someProp('name', columnName, column.allColumns)
     );
     const targetColumns = castedDefaultContent
-      ? column.allColumns.map(col => col.name).concat(filteredSummaryColumns)
+      ? column.allColumns.map(({ name }) => name).concat(filteredSummaryColumns)
       : summaryColumns;
 
     targetColumns.forEach(columnName => {

--- a/packages/toast-ui.grid/src/store/summary.ts
+++ b/packages/toast-ui.grid/src/store/summary.ts
@@ -46,17 +46,20 @@ export function createSummaryValue(
 }
 
 export function create({ column, data, summary }: SummaryOption): Summary {
-  let summaryColumnContents: SummaryColumnContents = {};
-  let summaryValues: SummaryValues = {};
+  const summaryColumnContents: SummaryColumnContents = {};
+  const summaryValues: SummaryValues = {};
   const { columnContent: orgColumnContent, defaultContent } = summary;
 
   if (Object.keys(summary).length) {
     const castedDefaultContent = castToSummaryColumnContent(defaultContent || '');
     const columnContent = orgColumnContent || {};
-    const summaryColumns = Object.keys(columnContent).filter(
+    const summaryColumns = Object.keys(columnContent);
+    const filteredSummaryColumns = Object.keys(columnContent).filter(
       columnName => !someProp('name', columnName, column.allColumns)
     );
-    const targetColumns = column.allColumns.map(col => col.name).concat(summaryColumns);
+    const targetColumns = castedDefaultContent
+      ? column.allColumns.map(col => col.name).concat(filteredSummaryColumns)
+      : summaryColumns;
 
     targetColumns.forEach(columnName => {
       const castedColumnContent = castToSummaryColumnContent(columnContent[columnName]);
@@ -65,10 +68,7 @@ export function create({ column, data, summary }: SummaryOption): Summary {
       summaryColumnContents[columnName] = content;
       summaryValues[columnName] = createSummaryValue(content, columnName, data);
     });
-
-    summaryColumnContents = observable(summaryColumnContents);
-    summaryValues = observable(summaryValues);
   }
 
-  return { summaryColumnContents, summaryValues, defaultContent };
+  return observable({ summaryColumnContents, summaryValues, defaultContent });
 }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* fixed that summary content is not changed after calling `setColumns` API, because summary column cannot observe the added column data through `setColumns` API
* additional context
  * the reactivity of summary has been based on the column cells, but it changed to based on summary root structure for effectivity.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
