### PR TITLE
fix: consider removing column filter state on calling `restetData` API option

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/filter.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/filter.spec.ts
@@ -974,4 +974,13 @@ describe('resetData API with filterState', () => {
       .invoke('getFilterState')
       .should('eq', null);
   });
+
+  it('should remove the filterState', () => {
+    invokeFilter('age', [{ code: 'eq', value: 10 }]);
+    const filterState = { columnName: 'age', columnFilterState: null };
+
+    cy.gridInstance().invoke('resetData', data, { filterState });
+
+    assertFilterBtnClass(false);
+  });
 });

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -24,7 +24,14 @@ import {
   isUndefined,
   silentSplice
 } from '../helper/common';
-import { OptRow, OptAppendRow, OptRemoveRow, ResetOptions } from '@t/options';
+import {
+  OptRow,
+  OptAppendRow,
+  OptRemoveRow,
+  ResetOptions,
+  FilterStateResetOption,
+  SortStateResetOption
+} from '@t/options';
 import {
   createViewRow,
   createData,
@@ -671,17 +678,8 @@ export function clearData(store: Store) {
   getDataManager(id).clearAll();
 }
 
-export function resetData(store: Store, inputData: OptRow[], options: ResetOptions) {
-  const { data, column, id } = store;
-  const { sortState, filterState } = options;
-  const { rawData, viewData } = createData({ data: inputData, column, lazyObservable: true });
-  const eventBus = getEventBus(id);
-  const gridEvent = new GridEvent();
-
-  initScrollPosition(store);
-  initFocus(store);
-  initSelection(store);
-
+function resetSortState(store: Store, sortState?: SortStateResetOption) {
+  const { data, column } = store;
   if (sortState) {
     const { columnName, ascending, multiple } = sortState;
 
@@ -692,10 +690,12 @@ export function resetData(store: Store, inputData: OptRow[], options: ResetOptio
   } else {
     initSortState(data);
   }
+}
 
+function resetFilterState(store: Store, filterState?: FilterStateResetOption) {
   if (filterState) {
     const { columnFilterState, columnName } = filterState;
-    const columnFilterOption = column.allColumnMap[columnName].filter;
+    const columnFilterOption = store.column.allColumnMap[columnName].filter;
 
     if (columnFilterOption) {
       if (columnFilterState) {
@@ -714,6 +714,22 @@ export function resetData(store: Store, inputData: OptRow[], options: ResetOptio
   } else {
     initFilter(store);
   }
+}
+
+export function resetData(store: Store, inputData: OptRow[], options: ResetOptions) {
+  const { data, column, id } = store;
+  const { sortState, filterState } = options;
+  const { rawData, viewData } = createData({ data: inputData, column, lazyObservable: true });
+  const eventBus = getEventBus(id);
+  const gridEvent = new GridEvent();
+
+  initScrollPosition(store);
+  initFocus(store);
+  initSelection(store);
+
+  resetSortState(store, sortState);
+  resetFilterState(store, filterState);
+
   updatePageOptions(store, { totalCount: rawData.length, page: 1 }, true);
   data.viewData = viewData;
   data.rawData = rawData;

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -63,7 +63,7 @@ import {
   updateSummaryValueByRow,
   updateAllSummaryValues
 } from './summary';
-import { initFilter, updateFilters } from './filter';
+import { initFilter, updateFilters, clearFilter } from './filter';
 import { getSelectionRange } from '../query/selection';
 import { initScrollPosition } from './viewport';
 import { isRowHeader } from '../helper/column';
@@ -698,14 +698,18 @@ export function resetData(store: Store, inputData: OptRow[], options: ResetOptio
     const columnFilterOption = column.allColumnMap[columnName].filter;
 
     if (columnFilterOption) {
-      const nextState = {
-        conditionFn: () => true,
-        type: columnFilterOption.type,
-        state: columnFilterState,
-        columnName,
-        operator: columnFilterOption.operator
-      };
-      updateFilters(store, columnName, nextState);
+      if (columnFilterState) {
+        const nextState = {
+          conditionFn: () => true,
+          type: columnFilterOption.type,
+          state: columnFilterState,
+          columnName,
+          operator: columnFilterOption.operator
+        };
+        updateFilters(store, columnName, nextState);
+      } else {
+        clearFilter(store, columnName);
+      }
     }
   } else {
     initFilter(store);

--- a/packages/toast-ui.grid/src/dispatch/filter.ts
+++ b/packages/toast-ui.grid/src/dispatch/filter.ts
@@ -209,6 +209,19 @@ export function updateFilters({ data }: Store, columnName: string, nextColumnFil
   }
 }
 
+export function clearFilter({ data }: Store, columnName: string) {
+  const filters = data.filters || [];
+  const filterIndex = findPropIndex('columnName', columnName, filters);
+
+  if (filterIndex >= 0) {
+    if (filters.length === 1) {
+      data.filters = null;
+    } else {
+      filters.splice(filterIndex, 1);
+    }
+  }
+}
+
 function clearAll(store: Store) {
   const gridEvent = emitBeforeFilter(store, 'beforeUnfilter', { columnName: null });
 
@@ -240,14 +253,15 @@ export function unfilter(store: Store, columnName?: string) {
     if (gridEvent.isStopped()) {
       return;
     }
-    const filterIndex = findPropIndex('columnName', columnName, filters);
-    if (filterIndex >= 0) {
-      if (filters.length === 1) {
-        data.filters = null;
-      } else {
-        filters.splice(filterIndex, 1);
-      }
-    }
+    clearFilter(store, columnName);
+    // const filterIndex = findPropIndex('columnName', columnName, filters);
+    // if (filterIndex >= 0) {
+    //   if (filters.length === 1) {
+    //     data.filters = null;
+    //   } else {
+    //     filters.splice(filterIndex, 1);
+    //   }
+    // }
 
     initLayerAndScrollAfterFiltering(store);
     updateAllSummaryValues(store);

--- a/packages/toast-ui.grid/src/dispatch/filter.ts
+++ b/packages/toast-ui.grid/src/dispatch/filter.ts
@@ -254,15 +254,6 @@ export function unfilter(store: Store, columnName?: string) {
       return;
     }
     clearFilter(store, columnName);
-    // const filterIndex = findPropIndex('columnName', columnName, filters);
-    // if (filterIndex >= 0) {
-    //   if (filters.length === 1) {
-    //     data.filters = null;
-    //   } else {
-    //     filters.splice(filterIndex, 1);
-    //   }
-    // }
-
     initLayerAndScrollAfterFiltering(store);
     updateAllSummaryValues(store);
     emitAfterFilter(store, 'afterUnfilter', columnName);

--- a/packages/toast-ui.grid/src/query/filter.ts
+++ b/packages/toast-ui.grid/src/query/filter.ts
@@ -61,8 +61,8 @@ export function createFilterEvent({ data }: Store, eventType: EventType, eventPa
      * Occurs before unfiltering
      * @event Grid#beforeUnfilter
      * @property {Grid} instance - Current grid instance
-     * @property {string} columnName- Target column name
-     * @property {Object} filterState- Current filter state
+     * @property {string} columnName - Target column name
+     * @property {Object} filterState - Current filter state
      */
     case 'beforeUnfilter':
     /**
@@ -70,16 +70,16 @@ export function createFilterEvent({ data }: Store, eventType: EventType, eventPa
      * @deprecated
      * @event Grid#filter
      * @property {Grid} instance - Current grid instance
-     * @property {string} columnName- Target column name
-     * @property {Object} filterState- Current filter state
+     * @property {string} columnName - Target column name
+     * @property {Object} filterState - Current filter state
      */
     case 'filter':
     /**
      * Occurs after filtering
      * @event Grid#afterFilter
      * @property {Grid} instance - Current grid instance
-     * @property {string} columnName- Target column name
-     * @property {Object} filterState- Current filter state
+     * @property {string} columnName - Target column name
+     * @property {Object} filterState - Current filter state
      */
     case 'afterFilter':
 
@@ -87,8 +87,8 @@ export function createFilterEvent({ data }: Store, eventType: EventType, eventPa
      * Occurs after unfiltering
      * @event Grid#afterUnfilter
      * @property {Grid} instance - Current grid instance
-     * @property {string} columnName- Target column name
-     * @property {Object} filterState- Current filter state
+     * @property {string} columnName - Target column name
+     * @property {Object} filterState - Current filter state
      */
     case 'afterUnfilter':
       props = {

--- a/packages/toast-ui.grid/src/query/sort.ts
+++ b/packages/toast-ui.grid/src/query/sort.ts
@@ -59,6 +59,12 @@ export function createSortEvent(eventType: EventType, eventParams: EventParams) 
      * @property {Grid} instance - Current grid instance
      */
     case 'beforeUnsort':
+      props = {
+        sortState,
+        columnName,
+        multiple
+      };
+      break;
     /**
      * Occurs after sorting.
      * @deprecated

--- a/packages/toast-ui.grid/types/index.d.ts
+++ b/packages/toast-ui.grid/types/index.d.ts
@@ -180,7 +180,7 @@ declare namespace tui {
 
     public clear(): void;
 
-    public resetData(data: OptRow[], options: ResetOptions): void;
+    public resetData(data: OptRow[], options?: ResetOptions): void;
 
     public addCellClassName(rowKey: RowKey, columnName: string, className: string): void;
 

--- a/packages/toast-ui.grid/types/options.d.ts
+++ b/packages/toast-ui.grid/types/options.d.ts
@@ -433,7 +433,18 @@ export interface OptI18nData {
   };
 }
 
+export interface SortStateResetOption {
+  columnName: string;
+  ascending: boolean;
+  multiple: boolean;
+}
+
+export interface FilterStateResetOption {
+  columnName: string;
+  columnFilterState?: FilterState[];
+}
+
 export interface ResetOptions {
-  sortState?: { columnName: string; ascending: boolean; multiple: boolean };
-  filterState?: { columnName: string; columnFilterState: FilterState[] };
+  sortState?: SortStateResetOption;
+  filterState?: FilterStateResetOption;
 }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* should consider removing column filter state on calling `restetData` API option


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
