### PR TITLE
fix: cannot find the row properly on calling getRow API after calling clearModifiedData

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/data.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/data.spec.ts
@@ -495,10 +495,6 @@ describe('getters', () => {
       cy.gridInstance()
         .invoke('getRow', 0)
         .should('have.subset', getRowDataWithAttrs(1));
-
-      cy.gridInstance()
-        .invoke('getRow', 1)
-        .should('have.subset', getRowDataWithAttrs(2));
     });
 
     it('should return row matching given rowKey regardless of filtering the data', () => {
@@ -507,10 +503,6 @@ describe('getters', () => {
       cy.gridInstance()
         .invoke('getRow', 0)
         .should('have.subset', getRowDataWithAttrs(1));
-
-      cy.gridInstance()
-        .invoke('getRow', 1)
-        .should('have.subset', getRowDataWithAttrs(2));
     });
 
     it('should return row matching given rowKey after appedngind the row and clearing modified data', () => {

--- a/packages/toast-ui.grid/cypress/integration/data.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/data.spec.ts
@@ -490,34 +490,105 @@ describe('getters', () => {
     };
   }
 
-  it('getRow() returns row matching given rowKey', () => {
-    cy.gridInstance()
-      .invoke('getRow', 0)
-      .should('have.subset', getRowDataWithAttrs(1));
+  context('getRow()', () => {
+    it('should return row matching given rowKey', () => {
+      cy.gridInstance()
+        .invoke('getRow', 0)
+        .should('have.subset', getRowDataWithAttrs(1));
 
-    cy.gridInstance()
-      .invoke('getRow', 1)
-      .should('have.subset', getRowDataWithAttrs(2));
+      cy.gridInstance()
+        .invoke('getRow', 1)
+        .should('have.subset', getRowDataWithAttrs(2));
+    });
+
+    it('should return row matching given rowKey regardless of filtering the data', () => {
+      cy.gridInstance().invoke('filter', 'name', [{ code: 'eq', value: 'Lee' }]);
+
+      cy.gridInstance()
+        .invoke('getRow', 0)
+        .should('have.subset', getRowDataWithAttrs(1));
+
+      cy.gridInstance()
+        .invoke('getRow', 1)
+        .should('have.subset', getRowDataWithAttrs(2));
+    });
+
+    it('should return row matching given rowKey after appedngind the row and clearing modified data', () => {
+      const row = {
+        name: 'Ryu',
+        age: 10,
+        _attributes: {
+          checkDisabled: false,
+          checked: false,
+          disabled: false,
+          className: {
+            row: [],
+            column: {}
+          },
+          rowNum: 2
+        }
+      };
+
+      cy.gridInstance().invoke('appendRow', { name: 'Ryu', age: 10 }, { at: 1 });
+      cy.gridInstance().invoke('clearModifiedData');
+
+      cy.gridInstance()
+        .invoke('getRow', 2)
+        .should('have.subset', row);
+    });
   });
 
-  it('getRowAt() returns row indexed by given index', () => {
-    cy.gridInstance()
-      .invoke('getRowAt', 0)
-      .should('have.subset', getRowDataWithAttrs(1));
+  context('getRowAt()', () => {
+    it('should return row by given index', () => {
+      cy.gridInstance()
+        .invoke('getRowAt', 0)
+        .should('have.subset', getRowDataWithAttrs(1));
 
-    cy.gridInstance()
-      .invoke('getRowAt', 1)
-      .should('have.subset', getRowDataWithAttrs(2));
+      cy.gridInstance()
+        .invoke('getRowAt', 1)
+        .should('have.subset', getRowDataWithAttrs(2));
+    });
+
+    it('should return row by given index regardless of filtering the data', () => {
+      cy.gridInstance().invoke('filter', 'name', [{ code: 'eq', value: 'Lee' }]);
+
+      cy.gridInstance()
+        .invoke('getRowAt', 0)
+        .should('have.subset', getRowDataWithAttrs(1));
+
+      cy.gridInstance()
+        .invoke('getRowAt', 1)
+        .should('have.subset', getRowDataWithAttrs(2));
+    });
   });
 
-  it('getIndexOfRow() returns the index of the row matching given rowKey', () => {
-    cy.gridInstance()
-      .invoke('getIndexOfRow', 0)
-      .should('eq', 0);
+  context('getIndexOfRow()', () => {
+    it('should return the index of the row matching given rowKey', () => {
+      cy.gridInstance()
+        .invoke('getIndexOfRow', 0)
+        .should('eq', 0);
 
-    cy.gridInstance()
-      .invoke('getIndexOfRow', 1)
-      .should('eq', 1);
+      cy.gridInstance()
+        .invoke('getIndexOfRow', 1)
+        .should('eq', 1);
+    });
+
+    it('should return the index of the row matching given rowKey regardless of filtering the data', () => {
+      cy.gridInstance().invoke('filter', 'name', [{ code: 'eq', value: 'Lee' }]);
+
+      cy.gridInstance()
+        .invoke('getIndexOfRow', 0)
+        .should('eq', 0);
+    });
+
+    it('should return the index of the row matching given rowKey after appedngind the row and clearing modified data', () => {
+      cy.gridInstance().invoke('appendRow', { name: 'Ryu', age: 10 }, { at: 1 });
+      cy.gridInstance().invoke('clearModifiedData');
+
+      cy.gridInstance()
+        .invoke('getIndexOfRow', 2)
+        .should('have.subset', 1);
+    });
   });
 
   it('getData() returns all rows', () => {

--- a/packages/toast-ui.grid/src/dataSource/manager/modifiedDataManager.ts
+++ b/packages/toast-ui.grid/src/dataSource/manager/modifiedDataManager.ts
@@ -58,6 +58,7 @@ export function getDataWithOptions(targetRows: Row[], options: ModifiedRowsOptio
 
 export function createManager(): ModifiedDataManager {
   let originData: OptRow[] = [];
+  let mixedOrder = false;
   const dataMap: ModifiedDataMap = {
     CREATE: [],
     UPDATE: [],
@@ -107,8 +108,9 @@ export function createManager(): ModifiedDataManager {
       return !!dataMap[type].length;
     },
 
-    push(type: ModificationTypeCode, row: Row) {
+    push(type: ModificationTypeCode, row: Row, mixed = false) {
       const { rowKey } = row;
+      mixedOrder = mixed;
       if (type === 'UPDATE' || type === 'DELETE') {
         splice('UPDATE', rowKey);
         // if the row was already registered in createdRows,
@@ -148,6 +150,10 @@ export function createManager(): ModifiedDataManager {
       dataMap.CREATE = [];
       dataMap.UPDATE = [];
       dataMap.DELETE = [];
+    },
+
+    isMixedOrder() {
+      return mixedOrder;
     }
   };
 }

--- a/packages/toast-ui.grid/src/dataSource/manager/modifiedDataManager.ts
+++ b/packages/toast-ui.grid/src/dataSource/manager/modifiedDataManager.ts
@@ -110,7 +110,7 @@ export function createManager(): ModifiedDataManager {
 
     push(type: ModificationTypeCode, row: Row, mixed = false) {
       const { rowKey } = row;
-      mixedOrder = mixed;
+      mixedOrder = mixedOrder || mixed;
       if (type === 'UPDATE' || type === 'DELETE') {
         splice('UPDATE', rowKey);
         // if the row was already registered in createdRows,

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -574,7 +574,7 @@ export function appendRow(store: Store, row: OptRow, options: OptAppendRow) {
   const { rawData, viewData, sortState, pageOptions } = data;
   const { at = rawData.length } = options;
   const { rawRow, viewRow, prevRow } = getCreatedRowInfo(store, at, row);
-  const appendedInMiddle = at !== rawData.length;
+  const inserted = at !== rawData.length;
 
   silentSplice(viewData, at, 0, viewRow);
   silentSplice(rawData, at, 0, rawRow);
@@ -582,7 +582,7 @@ export function appendRow(store: Store, row: OptRow, options: OptAppendRow) {
   updatePageOptions(store, { totalCount: pageOptions.totalCount! + 1 });
   updateHeights(store);
 
-  if (appendedInMiddle) {
+  if (inserted) {
     updateSortKey(data, at);
   }
 
@@ -592,10 +592,10 @@ export function appendRow(store: Store, row: OptRow, options: OptAppendRow) {
     updateRowSpanWhenAppend(rawData, prevRow, options.extendPrevRowSpan || false);
   }
 
-  getDataManager(id).push('CREATE', rawRow, appendedInMiddle);
+  getDataManager(id).push('CREATE', rawRow, inserted);
   updateSummaryValueByRow(store, rawRow, { type: 'APPEND' });
   setLoadingState(store, 'DONE');
-  updateRowNumber(store, at > 0 ? at - 1 : 0);
+  updateRowNumber(store, at ? at - 1 : 0);
   setDisabledAllCheckbox(store);
   setCheckedAllRows(store);
 }

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -574,6 +574,7 @@ export function appendRow(store: Store, row: OptRow, options: OptAppendRow) {
   const { rawData, viewData, sortState, pageOptions } = data;
   const { at = rawData.length } = options;
   const { rawRow, viewRow, prevRow } = getCreatedRowInfo(store, at, row);
+  const appendedInMiddle = at !== rawData.length;
 
   silentSplice(viewData, at, 0, viewRow);
   silentSplice(rawData, at, 0, rawRow);
@@ -581,7 +582,7 @@ export function appendRow(store: Store, row: OptRow, options: OptAppendRow) {
   updatePageOptions(store, { totalCount: pageOptions.totalCount! + 1 });
   updateHeights(store);
 
-  if (at !== rawData.length) {
+  if (appendedInMiddle) {
     updateSortKey(data, at);
   }
 
@@ -591,10 +592,10 @@ export function appendRow(store: Store, row: OptRow, options: OptAppendRow) {
     updateRowSpanWhenAppend(rawData, prevRow, options.extendPrevRowSpan || false);
   }
 
-  getDataManager(id).push('CREATE', rawRow);
+  getDataManager(id).push('CREATE', rawRow, appendedInMiddle);
   updateSummaryValueByRow(store, rawRow, { type: 'APPEND' });
   setLoadingState(store, 'DONE');
-  updateRowNumber(store, at);
+  updateRowNumber(store, at > 0 ? at - 1 : 0);
   setDisabledAllCheckbox(store);
   setCheckedAllRows(store);
 }
@@ -1014,7 +1015,7 @@ export function moveRow(store: Store, rowKey: RowKey, targetIndex: number) {
 
   resetSortKey(data, minIndex);
   updateRowNumber(store, minIndex);
-  getDataManager(id).push('UPDATE', rawRow);
+  getDataManager(id).push('UPDATE', rawRow, true);
 }
 
 export function scrollToNext(store: Store) {

--- a/packages/toast-ui.grid/src/dispatch/tree.ts
+++ b/packages/toast-ui.grid/src/dispatch/tree.ts
@@ -368,7 +368,7 @@ export function appendTreeRow(store: Store, row: OptRow, options: OptAppendTreeR
 
   rawRows.forEach(rawRow => {
     changeTreeRowsCheckedState(store, rawRow.rowKey, rawRow._attributes.checked);
-    getDataManager(id).push('CREATE', rawRow);
+    getDataManager(id).push('CREATE', rawRow, true);
   });
   setLoadingState(store, getLoadingState(rawData));
   updateRowNumber(store, startIdx);

--- a/packages/toast-ui.grid/src/grid.tsx
+++ b/packages/toast-ui.grid/src/grid.tsx
@@ -1150,7 +1150,7 @@ export default class Grid implements TuiGrid {
    */
   public getIndexOfRow(rowKey: RowKey) {
     const { data, column, id } = this.store;
-    return findIndexByRowKey(data, column, id, rowKey);
+    return findIndexByRowKey(data, column, id, rowKey, false);
   }
 
   /**

--- a/packages/toast-ui.grid/src/query/data.ts
+++ b/packages/toast-ui.grid/src/query/data.ts
@@ -78,9 +78,7 @@ export function findIndexByRowKey(
   const { filteredRawData, rawData, sortState } = data;
   const targetData = filtered ? filteredRawData : rawData;
   const dataManager = getDataManager(id);
-  const modified = dataManager
-    ? dataManager.isModifiedByType('CREATE') || dataManager.isModifiedByType('UPDATE')
-    : false;
+  const modified = dataManager ? dataManager.isMixedOrder() : false;
 
   if (!isRowSpanEnabled(sortState) || column.keyColumnName || modified) {
     return findPropIndex('rowKey', rowKey, targetData);

--- a/packages/toast-ui.grid/types/dataSource/index.d.ts
+++ b/packages/toast-ui.grid/types/dataSource/index.d.ts
@@ -108,8 +108,9 @@ export interface ModifiedDataManager {
   getAllModifiedData: (options: ModifiedRowsOptions) => ModifiedRows;
   isModified: () => boolean;
   isModifiedByType: (type: ModificationTypeCode) => boolean;
-  push: (type: ModificationTypeCode, row: Row) => void;
+  push: (type: ModificationTypeCode, row: Row, mixed?: boolean) => void;
   clearSpecificRows: (rowMap: MutationParams) => void;
   clear: (type: RequestTypeCode) => void;
   clearAll: () => void;
+  isMixedOrder: () => boolean;
 }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* fixed that its' not possible to find the row properly on calling getRow API after calling clearModifiedData


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
