### PR TITLE
fix: the js error is emitted when expanding the tree cell with resizable option

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/tree.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/tree.spec.ts
@@ -842,7 +842,7 @@ describe('with resizable column options', () => {
     ];
   });
 
-  it('width not automatically resize when expanded without resizable option', () => {
+  it('width should not be automatically resize when expanding without resizable option', () => {
     targetColumns[0].resizable = false;
     createGridWidthResizableOption();
 
@@ -867,7 +867,7 @@ describe('with resizable column options', () => {
     });
   });
 
-  it('width should be not resized when existing width is wider than child node width', () => {
+  it('width should not be resized when existing width is wider than child node width', () => {
     targetData[0]._children![0].c1 = 'short';
     createGridWidthResizableOption();
 
@@ -878,7 +878,7 @@ describe('with resizable column options', () => {
     assertColumnWidth('c1', DEPTH_ONE_MAX_WIDTH);
   });
 
-  it('width resize automatically with child expanded attribute', () => {
+  it('width should be resized automatically with child expanded attribute', () => {
     targetData[0]._children![0]._attributes!.expanded = true;
     createGridWidthResizableOption();
 

--- a/packages/toast-ui.grid/cypress/integration/tree.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/tree.spec.ts
@@ -1,7 +1,8 @@
 import { RowKey, CellValue } from '@t/store/data';
 import { OptColumn, OptGrid, OptRow } from '@t/options';
-import { cls } from '../../src/helper/dom';
 import GridEvent from '@/event/gridEvent';
+import { CellRenderer, CellRendererProps } from '@t/renderer';
+import { cls } from '../../src/helper/dom';
 
 type ModifiedType = 'createdRows' | 'updatedRows' | 'deletedRows';
 
@@ -791,23 +792,59 @@ describe('with resizable column options', () => {
   const DEPTH_TWO_MAX_WIDTH = 295;
   const DEPTH_THREE_MAX_WIDTH = 348;
 
-  beforeEach(() => {
-    data[0].c1 = 'looooooooooooooong contents';
-    data[0]._children[0]._attributes.expanded = false;
-    data[0]._children[0].c1 = 'looooooooooooooong child contents';
-    data[0]._children[0]._children[0].c1 = 'looooooooooooooong child child contents';
+  let targetData: OptRow[] = [];
+  let targetColumns: OptColumn[] = [];
 
-    columns[0].width = DEPTH_ONE_MAX_WIDTH;
-    columns[0].resizable = true;
-  });
-
-  it('width not automatically resize when expanded without resizable option', () => {
-    columns[0].resizable = false;
-    createGrid({
+  function createGridWidthResizableOption() {
+    cy.createGrid({
+      data: targetData,
+      columns: targetColumns,
       treeColumnOptions: {
         name: 'c1'
       }
     });
+  }
+
+  beforeEach(() => {
+    targetColumns = [
+      { name: 'c1', editor: 'text', width: DEPTH_ONE_MAX_WIDTH, resizable: true },
+      { name: 'c2' }
+    ];
+    targetData = [
+      {
+        c1: 'looooooooooooooong contents',
+        _children: [
+          {
+            c1: 'looooooooooooooong child contents',
+            _attributes: {
+              expanded: false
+            },
+            _children: [
+              {
+                c1: 'looooooooooooooong child child contents',
+                _attributes: {
+                  expanded: false
+                },
+                _children: [
+                  {
+                    c1: 'qux'
+                  },
+                  {
+                    c1: 'quxx',
+                    _children: []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ];
+  });
+
+  it('width not automatically resize when expanded without resizable option', () => {
+    targetColumns[0].resizable = false;
+    createGridWidthResizableOption();
 
     cy.gridInstance().invoke('expand', 0);
 
@@ -815,12 +852,8 @@ describe('with resizable column options', () => {
   });
 
   ['UI', 'API'].forEach(type => {
-    it(`width resize automatically when expand by ${type}`, () => {
-      createGrid({
-        treeColumnOptions: {
-          name: 'c1'
-        }
-      });
+    it(`width should be resized automatically when expanding by ${type}`, () => {
+      createGridWidthResizableOption();
 
       assertColumnWidth('c1', DEPTH_ONE_MAX_WIDTH);
 
@@ -834,14 +867,9 @@ describe('with resizable column options', () => {
     });
   });
 
-  it('width is not resized when existing width is wider than child node width', () => {
-    data[0]._children[0].c1 = 'short';
-
-    createGrid({
-      treeColumnOptions: {
-        name: 'c1'
-      }
-    });
+  it('width should be not resized when existing width is wider than child node width', () => {
+    targetData[0]._children![0].c1 = 'short';
+    createGridWidthResizableOption();
 
     assertColumnWidth('c1', DEPTH_ONE_MAX_WIDTH);
 
@@ -851,13 +879,8 @@ describe('with resizable column options', () => {
   });
 
   it('width resize automatically with child expanded attribute', () => {
-    data[0]._children[0]._attributes.expanded = true;
-
-    createGrid({
-      treeColumnOptions: {
-        name: 'c1'
-      }
-    });
+    targetData[0]._children![0]._attributes!.expanded = true;
+    createGridWidthResizableOption();
 
     assertColumnWidth('c1', DEPTH_ONE_MAX_WIDTH);
 
@@ -866,12 +889,38 @@ describe('with resizable column options', () => {
     assertColumnWidth('c1', DEPTH_THREE_MAX_WIDTH);
   });
 
-  it('width resize automatically when call expandAll()', () => {
-    createGrid({
-      treeColumnOptions: {
-        name: 'c1'
+  it('width should be resized automatically when calling expandAll()', () => {
+    createGridWidthResizableOption();
+
+    assertColumnWidth('c1', DEPTH_ONE_MAX_WIDTH);
+
+    cy.gridInstance().invoke('expandAll');
+
+    assertColumnWidth('c1', DEPTH_THREE_MAX_WIDTH);
+  });
+
+  it('width should be resized with custom renderer automatically when calling expandAll()', () => {
+    class CustomRenderer implements CellRenderer {
+      private el: HTMLElement;
+
+      constructor(props: CellRendererProps) {
+        const el = document.createElement('div');
+
+        this.el = el;
+        this.render(props);
       }
-    });
+
+      getElement() {
+        return this.el;
+      }
+
+      render(props: CellRendererProps) {
+        this.el.innerText = props.formattedValue || '';
+      }
+    }
+
+    targetColumns[0].renderer = CustomRenderer;
+    createGridWidthResizableOption();
 
     assertColumnWidth('c1', DEPTH_ONE_MAX_WIDTH);
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* enhancement
  * get the max text width using text length on the cells of resizable tree column for performance.
* bug fix
  * js error is displayed when getting the computed font style.
![image2](https://user-images.githubusercontent.com/37766175/84457620-2263d680-ac9e-11ea-934b-bf6253633796.png)
* related PR(#953)




---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
