### PR TITLE
fix: the removed row is not applied to grid properly

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/lazyObservable.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/lazyObservable.spec.ts
@@ -269,6 +269,21 @@ describe('should API is executed properly on lazy observable data', () => {
     cy.getCellByIdx(0, 1).should('have.text', 'Snoop Dogg');
     cy.getCellByIdx(0, 2).should('have.text', 'EP');
   });
+
+  it('removeRow()', () => {
+    cy.gridInstance().invoke('removeRow', 0);
+
+    cy.getRsideBody().should('have.cellData', [
+      ['X', 'Ed Sheeran', 'Deluxe'],
+      ['Moves Like Jagger', 'Maroon5', 'Single'],
+      ['A Head Full Of Dreams', 'Coldplay', 'Deluxe'],
+      ['21', 'Adele', 'Deluxe'],
+      ['Warm On A Cold Night', 'HONNE', 'EP'],
+      ['Take Me To The Alley', 'Gregory Porter', 'Deluxe'],
+      ['Make Out', 'LANY', 'EP'],
+      ['Get Lucky', 'Daft Punk', 'Single']
+    ]);
+  });
 });
 
 describe('should API is executed properly on lazy observable data(tree)', () => {

--- a/packages/toast-ui.grid/src/helper/observable.ts
+++ b/packages/toast-ui.grid/src/helper/observable.ts
@@ -231,3 +231,9 @@ export function unobservedInvoke(fn: Function) {
   fn();
   paused = false;
 }
+
+export function batchedInvokeObserver(fn: Function) {
+  pending = true;
+  fn();
+  pending = false;
+}


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
*  If the row is removed, it will not be displayed properly.
![2020-06-22 16-34-04 2020-06-22 16_34_15](https://user-images.githubusercontent.com/37766175/85260814-3ed5ef00-b4a6-11ea-9f0a-659233c3dad7.gif)
* additional context
  * when the row is removed or moved, there is the problem that calling observer multiple times which makes changed data from being not applied.  we can resolve the issue through batched update which prevents the unnecessary calling observer.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
