### PR TITLE
fix: modify `appendRows` row key value setting

### DIFF
--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -765,8 +765,11 @@ export function appendRows(store: Store, inputData: OptRow[]) {
 
   if (!column.keyColumnName) {
     const rowKey = getMaxRowKey(data);
-    inputData.forEach((row, index) => {
-      row.rowKey = rowKey + index;
+    inputData = inputData.map((row, index) => {
+      return {
+        ...row,
+        rowKey: rowKey + index,
+      };
     });
   }
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

fix ```appendRows``` API
If you add the same rows (for example, an empty value initialized), the rowKey is set the same.
<img width="766" alt="image" src="https://user-images.githubusercontent.com/33520085/87879480-07674d80-ca26-11ea-8e00-c75941169eb8.png">
 

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
