### PR TITLE
fix: copy prev editing value when `editingEvent` option is `click`

### DIFF
--- a/packages/toast-ui.grid/src/dispatch/focus.ts
+++ b/packages/toast-ui.grid/src/dispatch/focus.ts
@@ -18,7 +18,7 @@ export function startEditing(store: Store, rowKey: RowKey, columnName: string) {
     return;
   }
 
-  // makes the data observable to judge editable, disable of the cell;
+  // makes the data observable to judge editable, disable of the cell
   makeObservable(store, findIndexByRowKey(data, column, id, rowKey, false));
 
   if (!isEditableCell(data, column, foundIndex, columnName)) {

--- a/packages/toast-ui.grid/src/dispatch/keyboard.ts
+++ b/packages/toast-ui.grid/src/dispatch/keyboard.ts
@@ -64,7 +64,11 @@ export function moveTabFocus(store: Store, command: TabCommandType) {
     focus.navigating = true;
     changeFocus(store, nextRowKey, nextColumnName, id);
 
-    if (focus.tabMode === 'moveAndEdit') {
+    if (
+      focus.tabMode === 'moveAndEdit' &&
+      focus.rowKey === nextRowKey &&
+      focus.columnName === nextColumnName
+    ) {
       setTimeout(() => {
         startEditing(store, nextRowKey, nextColumnName);
       });

--- a/packages/toast-ui.grid/src/grid.tsx
+++ b/packages/toast-ui.grid/src/grid.tsx
@@ -672,7 +672,9 @@ export default class Grid implements TuiGrid {
    */
   public startEditing(rowKey: RowKey, columnName: string, setScroll?: boolean) {
     if (this.focus(rowKey, columnName, setScroll)) {
-      this.dispatch('startEditing', rowKey, columnName);
+      if (this.store.focus.rowKey === rowKey && this.store.focus.columnName === columnName) {
+        this.dispatch('startEditing', rowKey, columnName);
+      }
     }
   }
 

--- a/packages/toast-ui.grid/src/view/container.tsx
+++ b/packages/toast-ui.grid/src/view/container.tsx
@@ -1,7 +1,7 @@
 import { h, Component } from 'preact';
 import { EditingEvent } from '@t/store/focus';
 import { SummaryPosition } from '@t/store/summary';
-import { ViewRow, PageOptions } from '@t/store/data';
+import { ViewRow, PageOptions, RowKey } from '@t/store/data';
 import { RenderState } from '@t/store/renderState';
 import { LeftSide } from './leftSide';
 import { RightSide } from './rightSide';
@@ -42,6 +42,8 @@ interface StoreProps {
   scrollX: boolean;
   scrollY: boolean;
   renderState: RenderState;
+  focusedRowKey: RowKey | null;
+  focusedColumnName: string | null;
 }
 
 interface TouchEventInfo {
@@ -258,12 +260,14 @@ export class ContainerComp extends Component<Props> {
   };
 
   private startEditing(eventTarget: HTMLElement) {
-    const { dispatch } = this.props;
+    const { dispatch, focusedRowKey, focusedColumnName } = this.props;
     const address = getCellAddress(eventTarget);
 
     if (address) {
       const { rowKey, columnName } = address;
-      dispatch('startEditing', rowKey, columnName);
+      if (focusedRowKey === rowKey && focusedColumnName === columnName) {
+        dispatch('startEditing', rowKey, columnName);
+      }
     }
   }
 
@@ -394,5 +398,7 @@ export const Container = connect<StoreProps, OwnProps>(
     scrollX: dimension.scrollX,
     scrollY: dimension.scrollY,
     renderState,
+    focusedRowKey: focus.rowKey,
+    focusedColumnName: focus.columnName,
   })
 )(ContainerComp);


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* fixed that copy prev editing value when `editingEvent` option is `click`
![2020-08-11 17-22-41 2020-08-11 17_22_57](https://user-images.githubusercontent.com/37766175/89874827-57859a00-dbf7-11ea-985c-3ad49e77d7a6.gif)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
