### PR TITLE
fix: improve `check`, `uncheck` API performance

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/observerble.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/observerble.spec.ts
@@ -1,4 +1,10 @@
-import { notify, observable, observe } from '@/helper/observable';
+import {
+  notify,
+  observable,
+  observe,
+  batchObserver,
+  asyncInvokeObserver,
+} from '@/helper/observable';
 
 it('observe() should invoke callback function whenever related props changed', () => {
   const person = observable({
@@ -300,4 +306,34 @@ describe('batch update', () => {
     expect(callback1).to.be.callCount(4);
     expect(callback2).to.be.calledTwice;
   });
+});
+
+it('batched observer should not invoke observer', () => {
+  const callback = cy.stub();
+  const obj = observable({ num: 0 });
+
+  observe(() => {
+    callback(obj.num);
+  });
+
+  batchObserver(() => {
+    obj.num = 20;
+  });
+
+  expect(callback).to.be.calledOnce;
+});
+
+it('asyncInvokeObserver API should invoke observer asynchronously', () => {
+  const callback = cy.stub();
+  const obj = observable({ num: 0 });
+
+  for (let i = 0; i < 100; i += 1) {
+    asyncInvokeObserver(() => {
+      callback();
+      obj.num = 20;
+    });
+  }
+
+  cy.wrap(callback).should('be.calledOnce');
+  cy.wrap(obj).should('eql', { num: 20 });
 });

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -19,7 +19,7 @@ import {
   silentSplice,
 } from '../helper/common';
 import { createViewRow, createData, setRowRelationListItems, createRawRow } from '../store/data';
-import { notify, isObservable, batchedInvokeObserver } from '../helper/observable';
+import { notify, isObservable, batchObserver, asyncInvokeObserver } from '../helper/observable';
 import { initSelection } from './selection';
 import { getEventBus } from '../event/eventBus';
 import GridEvent from '../event/gridEvent';
@@ -292,7 +292,9 @@ export function check(store: Store, rowKey: RowKey) {
   if (allColumnMap[treeColumnName]) {
     changeTreeRowsCheckedState(store, rowKey, true);
   }
-  setCheckedAllRows(store);
+  asyncInvokeObserver(() => {
+    setCheckedAllRows(store);
+  });
 
   /**
    * Occurs when a checkbox in row header is checked
@@ -313,7 +315,9 @@ export function uncheck(store: Store, rowKey: RowKey) {
   if (allColumnMap[treeColumnName]) {
     changeTreeRowsCheckedState(store, rowKey, false);
   }
-  setCheckedAllRows(store);
+  asyncInvokeObserver(() => {
+    setCheckedAllRows(store);
+  });
 
   /**
    * Occurs when a checkbox in row header is unchecked
@@ -469,7 +473,7 @@ export function removeRow(store: Store, rowKey: RowKey, options: OptRemoveRow) {
   updatePageWhenRemovingRow(store, 1);
   removeUniqueInfoMap(id, rawData[rowIndex], column);
 
-  batchedInvokeObserver(() => {
+  batchObserver(() => {
     [removedRow] = rawData.splice(rowIndex, 1);
   });
   viewData.splice(rowIndex, 1);
@@ -708,7 +712,7 @@ export function moveRow(store: Store, rowKey: RowKey, targetIndex: number) {
   const [rawRow] = silentSplice(rawData, currentIndex, 1);
   const [viewRow] = silentSplice(viewData, currentIndex, 1);
 
-  batchedInvokeObserver(() => {
+  batchObserver(() => {
     rawData.splice(targetIndex, 0, rawRow);
   });
   viewData.splice(targetIndex, 0, viewRow);

--- a/packages/toast-ui.grid/src/dispatch/tree.ts
+++ b/packages/toast-ui.grid/src/dispatch/tree.ts
@@ -6,7 +6,7 @@ import { ColumnCoords } from '@t/store/columnCoords';
 import { Dimension } from '@t/store/dimension';
 import { createViewRow } from '../store/data';
 import { getRowHeight, findIndexByRowKey, findRowByRowKey, getLoadingState } from '../query/data';
-import { notify, batchedInvokeObserver } from '../helper/observable';
+import { notify, batchObserver } from '../helper/observable';
 import { getDataManager } from '../instance';
 import {
   isUpdatableRowAttr,
@@ -334,7 +334,7 @@ export function appendTreeRow(store: Store, row: OptRow, options: OptAppendTreeR
 
   fillMissingColumnData(column, rawRows);
 
-  batchedInvokeObserver(() => {
+  batchObserver(() => {
     rawData.splice(startIdx, 0, ...rawRows);
   });
   const viewRows = rawRows.map((rawRow) => createViewRow(id, rawRow, rawData, column));
@@ -372,7 +372,7 @@ export function removeTreeRow(store: Store, rowKey: RowKey) {
   const deleteCount = getDescendantRows(store, rowKey).length + 1;
   let removedRows: Row[] = [];
 
-  batchedInvokeObserver(() => {
+  batchObserver(() => {
     removedRows = rawData.splice(startIdx, deleteCount);
   });
   viewData.splice(startIdx, deleteCount);

--- a/packages/toast-ui.grid/src/renderer/default.ts
+++ b/packages/toast-ui.grid/src/renderer/default.ts
@@ -9,6 +9,9 @@ export class DefaultRenderer implements CellRenderer {
     const { ellipsis, whiteSpace } = props.columnInfo;
 
     el.className = cls('cell-content');
+    el.setAttribute('title', `${props.formattedValue}`);
+
+    // @TODO: we should remove below options and consider common the renderer option for style, attribute and class names
     if (ellipsis) {
       el.style.textOverflow = 'ellipsis';
     }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* The performance of `check` API is drastically slow down with large data.
* example code
```js
for (let i = 0; i < 8000; i += 1) {
  grid.check(i);
}
```
#### as-is
![2020-11-12 17-47-47 2020-11-12 17_48_10](https://user-images.githubusercontent.com/37766175/98917069-4490a780-250f-11eb-9472-0cd70d428eee.gif)

#### to-be
![2020-11-12 17-49-22 2020-11-12 17_49_32](https://user-images.githubusercontent.com/37766175/98917219-730e8280-250f-11eb-91f9-5218fa99db52.gif)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
