### PR TITLE
fix: trigger `scrollEnd` event when calling `clear` API

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/eventBus.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/eventBus.spec.ts
@@ -218,7 +218,7 @@ describe('scrollEnd', () => {
     cy.wrap(callback).should('not.be.called');
   });
 
-  it.only('should not occur scrollEnd event after calling resetData API', () => {
+  it('should not occur scrollEnd event after calling resetData API', () => {
     const callback = cy.stub();
 
     cy.gridInstance().invoke('on', 'scrollEnd', callback);

--- a/packages/toast-ui.grid/cypress/integration/eventBus.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/eventBus.spec.ts
@@ -218,15 +218,15 @@ describe('scrollEnd', () => {
     cy.wrap(callback).should('not.be.called');
   });
 
-  it('should not occur scrollEnd event after calling resetData API', () => {
+  it.only('should not occur scrollEnd event after calling resetData API', () => {
     const callback = cy.stub();
 
     cy.gridInstance().invoke('on', 'scrollEnd', callback);
 
-    // scroll horizontally
-    cy.focusAndWait(10, 'age');
+    // scroll at the vertically
+    cy.focusAndWait(10, 'name');
 
-    cy.gridInstance().invoke('resetData', [{ name: 'Lee', age: 20 }]);
+    cy.gridInstance().invoke('resetData', []);
 
     cy.wrap(callback).should('not.be.called');
   });

--- a/packages/toast-ui.grid/src/view/bodyArea.tsx
+++ b/packages/toast-ui.grid/src/view/bodyArea.tsx
@@ -85,7 +85,11 @@ class BodyAreaComp extends Component<Props> {
     dispatch('setScrollTop', scrollTop);
     if (side === 'R') {
       dispatch('setScrollLeft', scrollLeft);
-      if (scrollHeight - scrollTop === clientHeight && this.prevScrollLeft === scrollLeft) {
+      if (
+        scrollTop > 0 &&
+        scrollHeight - scrollTop === clientHeight &&
+        this.prevScrollLeft === scrollLeft
+      ) {
         const gridEvent = new GridEvent();
         /**
          * Occurs when scroll at the bottommost


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* `scrollEnd` event should not be triggered when scrollTop position equals `0`.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
