### PR TITLE
fix: add oneTimeBindingProps to React wrapper prop list (fix #1260)

### DIFF
--- a/packages/toast-ui.react-grid/index.d.ts
+++ b/packages/toast-ui.react-grid/index.d.ts
@@ -30,7 +30,11 @@ type EventMaps = {
   [K in keyof EventNameMapping]?: GridEventListener;
 };
 
-type Props = Omit<GridOptions, 'el'> & EventMaps & HTMLAttributes<HTMLElement>;
+type Props = Omit<GridOptions, 'el'> &
+  EventMaps &
+  HTMLAttributes<HTMLElement> & {
+    oneTimeBindingProps?: Array<'data' | 'columns' | 'bodyHeight' | 'frozenColumnCount'>;
+  };
 
 export default class Grid extends Component<Props> {
   public getInstance(): TuiGrid;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description
This is a fix for issue #1260.
The list of available array items for `oneTimeBindingProps` has been copied from [the documentation](https://github.com/nhn/tui.grid/tree/ad36346efc8d19d17109a7e86ac9c297e055d098/packages/toast-ui.react-grid#reactive-props).


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
