### PR TITLE
fix: copy the data without encoding

### DIFF
--- a/packages/toast-ui.grid/src/query/clipboard.ts
+++ b/packages/toast-ui.grid/src/query/clipboard.ts
@@ -94,13 +94,9 @@ function getValuesToString(store: Store) {
   return rowList
     .map(({ valueMap }) =>
       columnInRange
-        .map((targetColumn) => {
-          return getTextWithCopyOptionsApplied(
-            valueMap[targetColumn.name],
-            filteredRawData,
-            targetColumn
-          );
-        })
+        .map((targetColumn) =>
+          getTextWithCopyOptionsApplied(valueMap[targetColumn.name], filteredRawData, targetColumn)
+        )
         .join('\t')
     )
     .join('\n');

--- a/packages/toast-ui.grid/src/query/clipboard.ts
+++ b/packages/toast-ui.grid/src/query/clipboard.ts
@@ -27,8 +27,8 @@ function getTextWithCopyOptionsApplied(
   if (copyOptions) {
     if (copyOptions.customValue) {
       text = getCustomValue(copyOptions.customValue, valueMap.value, rawData, column);
-    } else if (copyOptions.useListItemText && editorOptions) {
-      const { listItems } = (editorOptions as unknown) as ListItemOptions;
+    } else if (copyOptions.useListItemText && editorOptions?.listItems) {
+      const { listItems } = editorOptions as ListItemOptions;
       const { value } = valueMap;
       let valueList = [value];
       const result: CellValue[] = [];
@@ -94,13 +94,13 @@ function getValuesToString(store: Store) {
   return rowList
     .map(({ valueMap }) =>
       columnInRange
-        .map(({ name }, index) =>
-          getTextWithCopyOptionsApplied(
-            valueMap[name],
+        .map((targetColumn) => {
+          return getTextWithCopyOptionsApplied(
+            valueMap[targetColumn.name],
             filteredRawData,
-            visibleColumnsWithRowHeader[index]
-          )
-        )
+            targetColumn
+          );
+        })
         .join('\t')
     )
     .join('\n');

--- a/packages/toast-ui.grid/src/view/clipboard.tsx
+++ b/packages/toast-ui.grid/src/view/clipboard.tsx
@@ -109,12 +109,12 @@ class ClipboardComp extends Component<Props> {
     let data;
     if (html && html.indexOf('table') !== -1) {
       // step 1: Append copied data on contenteditable element to parsing correctly table data.
-      el.innerHTML = html;
+      el.textContent = html;
       // step 2: Make grid data from cell data of appended table element.
       const { rows } = el.querySelector('tbody')!;
       data = convertTableToData(rows);
       // step 3: Empty contenteditable element to reset.
-      el.innerHTML = '';
+      el.textContent = '';
     } else {
       data = convertTextToData(clipboardData.getData('text/plain'));
     }

--- a/packages/toast-ui.grid/src/view/clipboard.tsx
+++ b/packages/toast-ui.grid/src/view/clipboard.tsx
@@ -82,7 +82,7 @@ class ClipboardComp extends Component<Props> {
           return;
         }
         const { store } = this.context;
-        this.el.innerHTML = getText(store);
+        this.el.textContent = getText(store);
 
         if (isSupportWindowClipboardData()) {
           setClipboardSelection(this.el.childNodes[0]);
@@ -175,7 +175,7 @@ class ClipboardComp extends Component<Props> {
     if (!this.el) {
       return;
     }
-    const text = this.el.innerHTML;
+    const text = this.el.textContent!;
     if (isSupportWindowClipboardData()) {
       (window as WindowWithClipboard).clipboardData!.setData('Text', text);
     } else if (ev.clipboardData) {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
#### fixed that copy the data encoded
* as-is
![2021-04-14 17-34-10 2021-04-14 17_34_20](https://user-images.githubusercontent.com/37766175/114681984-a2891b80-9d49-11eb-9913-4b3c48ae9a98.gif)

* to-be
![2021-04-14 17-31-19 2021-04-14 17_31_31](https://user-images.githubusercontent.com/37766175/114681960-9c933a80-9d49-11eb-9ccc-d52a12c72470.gif)

#### fixed that copyOptions is not applied properly with selected cell
* as-is
![2021-04-14 17-46-55 2021-04-14 17_47_12](https://user-images.githubusercontent.com/37766175/114682212-d82e0480-9d49-11eb-8f5f-bbab698d386a.gif)


* to-be
![2021-04-14 17-47-34 2021-04-14 17_47_48](https://user-images.githubusercontent.com/37766175/114682244-debc7c00-9d49-11eb-901a-7f027d709870.gif)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
