### PR TITLE
feat: tree drag and drop

### DIFF
--- a/packages/toast-ui.grid/cypress/helper/util.ts
+++ b/packages/toast-ui.grid/cypress/helper/util.ts
@@ -1,3 +1,5 @@
+import { RowKey } from '@t/store/data';
+
 type Address = [number, number];
 
 export function clipboardType(key: string) {
@@ -33,4 +35,11 @@ export function setSelectionUsingMouse(start: Address, end: Address) {
         .trigger('mousemove', { pageX: left + 10, pageY: top + 10 })
         .trigger('mouseup');
     });
+}
+
+export function dragAndDrop(rowKey: RowKey, position: number) {
+  cy.getCell(rowKey, '_draggable')
+    .trigger('mousedown')
+    .trigger('mousemove', { pageY: position, force: true })
+    .trigger('mouseup', { force: true });
 }

--- a/packages/toast-ui.grid/cypress/integration/data.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/data.spec.ts
@@ -2,7 +2,7 @@ import { OptGrid } from '@t/options';
 import { Row, RowKey } from '@t/store/data';
 import { cls } from '@/helper/dom';
 import { FormatterProps } from '@t/store/column';
-import { invokeFilter, applyAliasHeaderCheckbox } from '../helper/util';
+import { invokeFilter, applyAliasHeaderCheckbox, dragAndDrop } from '../helper/util';
 import { assertGridHasRightRowNumber, assertHeaderCheckboxStatus } from '../helper/assert';
 
 function assertHeaderCheckboxDisabled(disable: boolean) {
@@ -1026,10 +1026,7 @@ describe('D&D', () => {
       ['Han', '40'],
     ]);
 
-    cy.getCell(1, '_draggable')
-      .trigger('mousedown')
-      .trigger('mousemove', { pageY: 140, force: true })
-      .trigger('mouseup', { force: true });
+    dragAndDrop(1, 140);
 
     cy.getRsideBody().should('have.cellData', [
       ['Kim', '10'],
@@ -1047,10 +1044,7 @@ describe('D&D', () => {
       ['Han', '40'],
     ]);
 
-    cy.getCell(1, '_draggable')
-      .trigger('mousedown')
-      .trigger('mousemove', { pageY: 40, force: true })
-      .trigger('mouseup', { force: true });
+    dragAndDrop(1, 40);
 
     cy.getRsideBody().should('have.cellData', [
       ['Lee', '20'],
@@ -1063,10 +1057,7 @@ describe('D&D', () => {
   it('should remove the focus when triggering mousedown to drag element', () => {
     cy.gridInstance().invoke('focus', 1, 'name');
 
-    cy.getCell(1, '_draggable')
-      .trigger('mousedown')
-      .trigger('mousemove', { pageY: 40, force: true })
-      .trigger('mouseup', { force: true });
+    dragAndDrop(1, 40);
 
     getActiveFocusLayer().should('not.exist');
   });

--- a/packages/toast-ui.grid/cypress/integration/data.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/data.spec.ts
@@ -1015,7 +1015,7 @@ describe('D&D', () => {
       { name: 'age', editor: 'text', sortable: true },
     ];
 
-    cy.createGrid({ data: largeData, columns, scrollY: true, bodyHeight: 400, draggableRow: true });
+    cy.createGrid({ data: largeData, columns, scrollY: true, bodyHeight: 400, draggable: true });
   });
 
   it('should move the row by dragging the row(bottom direction)', () => {

--- a/packages/toast-ui.grid/cypress/integration/eventBus.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/eventBus.spec.ts
@@ -171,10 +171,10 @@ it('onGridBeforeDestroy', () => {
   cy.wrap(callback).should('be.calledOnce');
 });
 
-it('columnResize', () => {
-  const callback = cy.stub();
+it.only('columnResize', () => {
+  const stub = cy.stub();
 
-  cy.gridInstance().invoke('on', 'columnResize', callback);
+  cy.gridInstance().invoke('on', 'columnResize', stub);
 
   cy.getByCls('column-resize-handle')
     .first()
@@ -182,8 +182,8 @@ it('columnResize', () => {
     .trigger('mousemove', { pageX: 400 })
     .trigger('mouseup');
 
-  cy.wrap(callback).should('be.calledWithMatch', {
-    resizedColumns: [{ columnName: 'name', width: 311 }],
+  cy.wrap(stub).should('be.calledWithMatch', {
+    resizedColumns: [{ columnName: 'name', width: 271 }],
   });
 });
 

--- a/packages/toast-ui.grid/cypress/integration/eventBus.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/eventBus.spec.ts
@@ -171,7 +171,7 @@ it('onGridBeforeDestroy', () => {
   cy.wrap(callback).should('be.calledOnce');
 });
 
-it.only('columnResize', () => {
+it('columnResize', () => {
   const stub = cy.stub();
 
   cy.gridInstance().invoke('on', 'columnResize', stub);

--- a/packages/toast-ui.grid/cypress/integration/eventBus.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/eventBus.spec.ts
@@ -20,7 +20,7 @@ beforeEach(() => {
   cy.createGrid({
     data,
     columns,
-    draggableRow: true,
+    draggable: true,
     bodyHeight: 150,
     width: 500,
     rowHeaders: ['rowNum', 'checkbox'],
@@ -708,7 +708,7 @@ describe('D&D', () => {
 
     cy.wrap(stub).should('be.calledWithMatch', {
       rowKey: 0,
-      currentRowKey: 1,
+      targetRowKey: 1,
     });
   });
 
@@ -723,7 +723,7 @@ describe('D&D', () => {
 
     cy.wrap(stub).should('be.calledWithMatch', {
       rowKey: 0,
-      currentRowKey: 1,
+      targetRowKey: 1,
     });
   });
 });

--- a/packages/toast-ui.grid/cypress/integration/eventBus.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/eventBus.spec.ts
@@ -20,6 +20,7 @@ beforeEach(() => {
   cy.createGrid({
     data,
     columns,
+    draggableRow: true,
     bodyHeight: 150,
     width: 500,
     rowHeaders: ['rowNum', 'checkbox'],
@@ -678,4 +679,51 @@ describe('beforeChange, afterChange', () => {
     ]);
   });
   // @TODO: add test case when pasting the data
+});
+
+describe('D&D', () => {
+  it('dragStart event', () => {
+    const stub = cy.stub();
+
+    cy.gridInstance().invoke('on', 'dragStart', stub);
+    cy.getCell(0, '_draggable')
+      .trigger('mousedown')
+      .then(() => {
+        cy.getByCls('floating-row').then((floatingRow) => {
+          cy.wrap(stub).should('be.calledWithMatch', {
+            rowKey: 0,
+            floatingRow: floatingRow[0],
+          });
+        });
+      });
+  });
+
+  it('drag event', () => {
+    const stub = cy.stub();
+    cy.gridInstance().invoke('on', 'drag', stub);
+
+    cy.getCell(0, '_draggable')
+      .trigger('mousedown')
+      .trigger('mousemove', { pageY: 100, force: true });
+
+    cy.wrap(stub).should('be.calledWithMatch', {
+      rowKey: 0,
+      currentRowKey: 1,
+    });
+  });
+
+  it('drop event', () => {
+    const stub = cy.stub();
+    cy.gridInstance().invoke('on', 'drop', stub);
+
+    cy.getCell(0, '_draggable')
+      .trigger('mousedown')
+      .trigger('mousemove', { pageY: 100, force: true })
+      .trigger('mouseup', { force: true });
+
+    cy.wrap(stub).should('be.calledWithMatch', {
+      rowKey: 0,
+      currentRowKey: 1,
+    });
+  });
 });

--- a/packages/toast-ui.grid/cypress/integration/tree.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/tree.spec.ts
@@ -1043,7 +1043,7 @@ describe('move tree row', () => {
 
     cy.createGrid({
       data: treeData,
-      draggableRow: true,
+      draggable: true,
       columns: [{ name: 'c1' }],
       treeColumnOptions: {
         name: 'c1',

--- a/packages/toast-ui.grid/docs/en/custom-event.md
+++ b/packages/toast-ui.grid/docs/en/custom-event.md
@@ -119,6 +119,9 @@ grid.on('mousedown', function(ev) {
 - `scrollEnd` : When scrolling at the bottommost
 - `beforeChange`: Before one or more cells is changed
 - `afterChange`: After one or more cells is changed
+- `dragStart`: Drag to start the movement of the row (only occurs if the `dragableRow` option is enabled)
+- `drag`: Dragging to move row (only occurs if the `dragableRow` option is enabled)
+- `drop`: When the drag is over and the row movement is complete. (only occurs if the `dragableRow` option is enabled)
 
 There are other events that can be used when using `DataSource`.
 

--- a/packages/toast-ui.grid/docs/en/custom-event.md
+++ b/packages/toast-ui.grid/docs/en/custom-event.md
@@ -119,9 +119,9 @@ grid.on('mousedown', function(ev) {
 - `scrollEnd` : When scrolling at the bottommost
 - `beforeChange`: Before one or more cells is changed
 - `afterChange`: After one or more cells is changed
-- `dragStart`: Drag to start the movement of the row (only occurs if the `dragableRow` option is enabled)
-- `drag`: Dragging to move row (only occurs if the `dragableRow` option is enabled)
-- `drop`: When the drag is over and the row movement is complete. (only occurs if the `dragableRow` option is enabled)
+- `dragStart`: Drag to start the movement of the row (only occurs if the `dragable` option is enabled)
+- `drag`: Dragging to move row (only occurs if the `dragable` option is enabled)
+- `drop`: When the drag is over and the row movement is complete. (only occurs if the `dragable` option is enabled)
 
 There are other events that can be used when using `DataSource`.
 

--- a/packages/toast-ui.grid/docs/ko/custom-event.md
+++ b/packages/toast-ui.grid/docs/ko/custom-event.md
@@ -119,9 +119,9 @@ grid.on('mousedown', (ev) => {
 - `scrollEnd` : 스크롤 위치가 가장 하단에 도달한 경우
 - `beforeChange`: 하나 또는 여러 개의 셀 값이 변경되기 전
 - `afterChange`: 하나 또는 여러 개의 셀 값이 변경된 후
-- `dragStart`: 드래그하여 로우의 이동을 시작했을 때(`draggableRow` 옵션이 활성화된 경우만 발생)
-- `drag`: 드래그하여 로우를 이동하는 중(`draggableRow` 옵션이 활성화된 경우만 발생)
-- `drop`: 드래그가 끝나고 로우 이동을 완료하였을 때(`draggableRow` 옵션이 활성화된 경우만 발생)
+- `dragStart`: 드래그하여 로우의 이동을 시작했을 때(`draggable` 옵션이 활성화된 경우만 발생)
+- `drag`: 드래그하여 로우를 이동하는 중(`draggable` 옵션이 활성화된 경우만 발생)
+- `drop`: 드래그가 끝나고 로우 이동을 완료하였을 때(`draggable` 옵션이 활성화된 경우만 발생)
 
 `DataSource`를 이용할 때 사용할 수 있는 이벤트는 다음과 같다.
 

--- a/packages/toast-ui.grid/docs/ko/custom-event.md
+++ b/packages/toast-ui.grid/docs/ko/custom-event.md
@@ -119,6 +119,9 @@ grid.on('mousedown', (ev) => {
 - `scrollEnd` : 스크롤 위치가 가장 하단에 도달한 경우
 - `beforeChange`: 하나 또는 여러 개의 셀 값이 변경되기 전
 - `afterChange`: 하나 또는 여러 개의 셀 값이 변경된 후
+- `dragStart`: 드래그하여 로우의 이동을 시작했을 때(`draggableRow` 옵션이 활성화된 경우만 발생)
+- `drag`: 드래그하여 로우를 이동하는 중(`draggableRow` 옵션이 활성화된 경우만 발생)
+- `drop`: 드래그가 끝나고 로우 이동을 완료하였을 때(`draggableRow` 옵션이 활성화된 경우만 발생)
 
 `DataSource`를 이용할 때 사용할 수 있는 이벤트는 다음과 같다.
 

--- a/packages/toast-ui.grid/src/css/grid.css
+++ b/packages/toast-ui.grid/src/css/grid.css
@@ -953,6 +953,7 @@
   position: absolute;
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.08);
   border-radius: 3px;
+  overflow: hidden;
 }
 
 .tui-grid-floating-cell {

--- a/packages/toast-ui.grid/src/css/grid.css
+++ b/packages/toast-ui.grid/src/css/grid.css
@@ -974,6 +974,13 @@
   display: inline-block;
 }
 
+.tui-grid-floating-line {
+  position: absolute;
+  height: 1px;
+  background: #00a9ff;
+  display: none;
+}
+
 .tui-grid-cell.dragging {
   opacity: 0.5;
 }

--- a/packages/toast-ui.grid/src/css/grid.css
+++ b/packages/toast-ui.grid/src/css/grid.css
@@ -951,12 +951,29 @@
   color: #5a6268;
   width: 100%;
   position: absolute;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.08);
+  border-radius: 3px;
 }
 
 .tui-grid-floating-cell {
   display: inline-block;
 }
 
+.tui-grid-floating-tree-cell {
+  padding: 0 10px;
+}
+
+.tui-grid-floating-tree-cell-content {
+  margin-left: 10px;
+  vertical-align: middle
+}
+
+.tui-grid-floating-tree-cell .tui-grid-tree-icon {
+  position: relative;
+  margin-top: -14px;
+  display: inline-block;
+}
+
 .tui-grid-cell.dragging {
-  opacity: 0.3;
+  opacity: 0.5;
 }

--- a/packages/toast-ui.grid/src/css/grid.css
+++ b/packages/toast-ui.grid/src/css/grid.css
@@ -977,3 +977,7 @@
 .tui-grid-cell.dragging {
   opacity: 0.5;
 }
+
+.tui-grid-cell.parent-cell {
+  background-color: rgba(0, 169, 255, 0.15)
+}

--- a/packages/toast-ui.grid/src/dispatch/tree.ts
+++ b/packages/toast-ui.grid/src/dispatch/tree.ts
@@ -5,8 +5,15 @@ import { Column, ColumnInfo } from '@t/store/column';
 import { ColumnCoords } from '@t/store/columnCoords';
 import { Dimension } from '@t/store/dimension';
 import { createViewRow } from '../store/data';
-import { getRowHeight, findIndexByRowKey, findRowByRowKey, getLoadingState } from '../query/data';
-import { notify, batchObserver } from '../helper/observable';
+import {
+  getRowHeight,
+  findIndexByRowKey,
+  findRowByRowKey,
+  getLoadingState,
+  isSorted,
+  isFiltered,
+} from '../query/data';
+import { notify, batchObserver, getOriginObject, Observable } from '../helper/observable';
 import { getDataManager } from '../instance';
 import {
   isUpdatableRowAttr,
@@ -30,7 +37,7 @@ import {
 import { getEventBus } from '../event/eventBus';
 import GridEvent from '../event/gridEvent';
 import { flattenTreeData, getTreeIndentWidth } from '../store/helper/tree';
-import { findProp, findPropIndex, removeArrayItem } from '../helper/common';
+import { findProp, findPropIndex, removeArrayItem, some } from '../helper/common';
 import { getComputedFontStyle, getTextWidth } from '../helper/dom';
 import { fillMissingColumnData } from './lazyObservable';
 import { getColumnSide } from '../query/column';
@@ -335,10 +342,11 @@ export function appendTreeRow(store: Store, row: OptRow, options: OptAppendTreeR
 
   fillMissingColumnData(column, rawRows);
 
+  const viewRows = rawRows.map((rawRow) => createViewRow(id, rawRow, rawData, column));
+
   batchObserver(() => {
     rawData.splice(startIdx, 0, ...rawRows);
   });
-  const viewRows = rawRows.map((rawRow) => createViewRow(id, rawRow, rawData, column));
   viewData.splice(startIdx, 0, ...viewRows);
 
   const rowHeights = rawRows.map((rawRow) => {
@@ -390,4 +398,53 @@ function postUpdateAfterManipulation(store: Store, rowIndex: number, rows?: Row[
   updateRowNumber(store, rowIndex);
   setCheckedAllRows(store);
   setAutoResizingColumnWidths(store, rows);
+}
+
+export function moveTreeRow(store: Store, rowKey: RowKey, targetIndex: number, appended?: boolean) {
+  const { data, column, id } = store;
+  const { rawData } = data;
+  const targetRow = rawData[targetIndex];
+
+  if (!targetRow || isSorted(data) || isFiltered(data)) {
+    return;
+  }
+
+  const currentIndex = findIndexByRowKey(data, column, id, rowKey, false);
+  const row = rawData[currentIndex];
+
+  if (currentIndex === -1 || currentIndex === targetIndex) {
+    return;
+  }
+
+  const childRows = getDescendantRows(store, rowKey);
+  const minIndex = Math.min(currentIndex, targetIndex);
+  const moveToChild = some((childRow) => childRow.rowKey === targetRow.rowKey, childRows);
+
+  if (!moveToChild) {
+    removeTreeRow(store, rowKey);
+    const originRow = getOriginObject(row as Observable<Row>);
+
+    getDataManager(id).push('UPDATE', targetRow, true);
+    getDataManager(id).push('UPDATE', row, true);
+
+    if (appended) {
+      appendTreeRow(store, originRow, { parentRowKey: targetRow.rowKey });
+    } else {
+      const { parentRowKey } = targetRow._attributes.tree!;
+      const parentIndex = findIndexByRowKey(data, column, id, parentRowKey);
+      let offset = targetIndex;
+
+      // calculate the moving index for considering removed rows
+      if (targetIndex > currentIndex) {
+        const indexWithoutRemovedRows = targetIndex - (childRows.length + 1);
+        offset =
+          parentIndex === -1 ? indexWithoutRemovedRows : indexWithoutRemovedRows - parentIndex - 1;
+      } else {
+        offset = parentIndex === -1 ? targetIndex : targetIndex - parentIndex - 1;
+      }
+
+      appendTreeRow(store, originRow, { parentRowKey, offset });
+    }
+    postUpdateAfterManipulation(store, minIndex);
+  }
 }

--- a/packages/toast-ui.grid/src/dispatch/tree.ts
+++ b/packages/toast-ui.grid/src/dispatch/tree.ts
@@ -424,12 +424,12 @@ export function moveTreeRow(
   }
 
   const currentIndex = findIndexByRowKey(data, column, id, rowKey, false);
-  const row = rawData[currentIndex];
 
   if (currentIndex === -1 || currentIndex === targetIndex) {
     return;
   }
 
+  const row = rawData[currentIndex];
   const childRows = getDescendantRows(store, rowKey);
   const minIndex = Math.min(currentIndex, targetIndex);
   const moveToChild = some((childRow) => childRow.rowKey === targetRow.rowKey, childRows);
@@ -446,7 +446,7 @@ export function moveTreeRow(
     } else {
       const { parentRowKey } = targetRow._attributes.tree!;
       const parentIndex = findIndexByRowKey(data, column, id, parentRowKey);
-      let offset = targetIndex;
+      let offset: number;
 
       // calculate the moving index for considering removed rows
       if (targetIndex > currentIndex) {

--- a/packages/toast-ui.grid/src/grid.tsx
+++ b/packages/toast-ui.grid/src/grid.tsx
@@ -268,6 +268,7 @@ if ((module as any).hot) {
  *      @param {function} [options.onGridMounted] - The function that will be called after rendering the grid.
  *      @param {function} [options.onGridUpdated] - The function that will be called after updating the all data of the grid and rendering the grid.
  *      @param {function} [options.onGridBeforeDestroy] - The function that will be called before destroying the grid.
+ *      @param {boolean} [options.draggable] - Whether to enable to drag the row for changing the order of rows.
  */
 export default class Grid implements TuiGrid {
   private el: HTMLElement;

--- a/packages/toast-ui.grid/src/grid.tsx
+++ b/packages/toast-ui.grid/src/grid.tsx
@@ -17,6 +17,7 @@ import {
   OptFilter,
   LifeCycleEventName,
   ResetOptions,
+  OptMoveRow,
 } from '@t/options';
 import { Store } from '@t/store';
 import { RowKey, CellValue, Row, InvalidRow } from '@t/store/data';
@@ -1634,10 +1635,18 @@ export default class Grid implements TuiGrid {
    * Move the row identified by the specified rowKey to target index.
    * If data is sorted or filtered, this couldn't be used.
    * @param {number|string} rowKey - The unique key of the row
-   * @param {number} targetIndex - target index for moving
+   * @param {number} targetIndex - Target index for moving
+   * @param {Object} [options] - Options
+   * @param {number} [options.appended] - This option for only tree data. Whether the row is appended to other row as the child.
    */
-  public moveRow(rowKey: RowKey, targetIndex: number) {
-    this.dispatch('moveRow', rowKey, targetIndex);
+  public moveRow(rowKey: RowKey, targetIndex: number, options: OptMoveRow = { appended: false }) {
+    const { column } = this.store;
+
+    if (column.treeColumnName) {
+      this.dispatch('moveTreeRow', rowKey, targetIndex, options);
+    } else {
+      this.dispatch('moveRow', rowKey, targetIndex);
+    }
   }
 
   /**

--- a/packages/toast-ui.grid/src/helper/dom.ts
+++ b/packages/toast-ui.grid/src/helper/dom.ts
@@ -133,7 +133,8 @@ export type ClassNameType =
   | 'floating-row'
   | 'floating-cell'
   | 'floating-tree-cell'
-  | 'floating-tree-cell-content';
+  | 'floating-tree-cell-content'
+  | 'floating-line';
 
 const CLS_PREFIX = 'tui-grid-';
 

--- a/packages/toast-ui.grid/src/helper/dom.ts
+++ b/packages/toast-ui.grid/src/helper/dom.ts
@@ -131,7 +131,9 @@ export type ClassNameType =
   | 'editor-datepicker-layer'
   | 'row-header-draggable'
   | 'floating-row'
-  | 'floating-cell';
+  | 'floating-cell'
+  | 'floating-tree-cell'
+  | 'floating-tree-cell-content';
 
 const CLS_PREFIX = 'tui-grid-';
 

--- a/packages/toast-ui.grid/src/query/draggable.ts
+++ b/packages/toast-ui.grid/src/query/draggable.ts
@@ -1,5 +1,5 @@
 import { Store } from '@t/store';
-import { RowKey, ViewRow } from '@t/store/data';
+import { RowKey, ViewRow, Row } from '@t/store/data';
 import { findOffsetIndex, fromArray } from '../helper/common';
 import { cls } from '../helper/dom';
 import { findIndexByRowKey } from './data';
@@ -15,6 +15,7 @@ export interface DraggableInfo {
   row: HTMLElement;
   rowKey: RowKey;
   line: HTMLElement;
+  targetRow?: Row;
 }
 
 const EXCEED_RATIO = 0.8;
@@ -112,7 +113,7 @@ export function createDraggableInfo(store: Store, posInfo: PosInfo): DraggableIn
 }
 
 export function getMovedPosAndIndex(store: Store, { pageY, top, scrollTop }: PosInfo) {
-  const { rowCoords, dimension, column } = store;
+  const { rowCoords, dimension, column, data } = store;
   const { headerHeight } = dimension;
   const offsetTop = pageY - top + scrollTop;
   let index = findOffsetIndex(rowCoords.offsets, offsetTop);
@@ -127,6 +128,7 @@ export function getMovedPosAndIndex(store: Store, { pageY, top, scrollTop }: Pos
     index,
     offsetTop: offsetTop - scrollTop + headerHeight,
     height: rowCoords.offsets[index] - scrollTop + headerHeight,
+    targetRow: data.rawData[index],
   };
 }
 

--- a/packages/toast-ui.grid/src/query/draggable.ts
+++ b/packages/toast-ui.grid/src/query/draggable.ts
@@ -1,7 +1,7 @@
 import { Store } from '@t/store';
 import { RowKey } from '@t/store/data';
 import { findOffsetIndex, fromArray } from '../helper/common';
-import { cls } from '../helper/dom';
+import { cls, dataAttr } from '../helper/dom';
 
 interface PosInfo {
   pageY: number;
@@ -13,38 +13,47 @@ interface PosInfo {
 export interface DraggableInfo {
   row: HTMLElement;
   rowKey: RowKey;
+  line: HTMLElement;
 }
 
 const EXCEED_RATIO = 0.8;
 
-function createFloatingDraggableRow(offsetTop: number, cells: Element[]) {
-  const row = document.createElement('div');
+function createCells(cell: Element) {
+  const el = document.createElement('div');
+  el.className = cls('floating-cell');
+  el.style.width = window.getComputedStyle(cell).width;
+
+  for (let i = 0; i < cell.childNodes.length; i += 1) {
+    // the cell is not complex structure, so there is no the performance problem
+    el.appendChild(cell.childNodes[i].cloneNode(true));
+  }
+
+  return el;
+}
+
+function createFloatingDraggableRow(offsetTop: number, cells: Element[], treeColumnName?: string) {
+  const cellElements = treeColumnName
+    ? cells.filter((cell) => cell.getAttribute(dataAttr.COLUMN_NAME) === treeColumnName)
+    : cells;
   // get original table row height
   const height = `${cells[0].parentElement!.clientHeight}px`;
+  const row = document.createElement('div');
 
   row.className = cls('floating-row');
   row.style.height = height;
   row.style.lineHeight = height;
   row.style.top = `${offsetTop}px`;
+  row.style.width = 'auto';
 
-  cells.forEach((cell) => {
-    const el = document.createElement('div');
-    el.className = cls('floating-cell');
-    el.style.width = window.getComputedStyle(cell).width;
-
-    for (let i = 0; i < cell.childNodes.length; i += 1) {
-      // the cell is not complex structure, so there is no the performance problem
-      el.appendChild(cell.childNodes[i].cloneNode(true));
-    }
-
-    row.appendChild(el);
+  cellElements.forEach((cell) => {
+    row.appendChild(createCells(cell));
   });
 
   return row;
 }
 
 export function createDraggableInfo(store: Store, posInfo: PosInfo): DraggableInfo | null {
-  const { data } = store;
+  const { data, column } = store;
   const { rawData, filters } = data;
 
   // if there is any filter condition, cannot drag the row
@@ -56,17 +65,39 @@ export function createDraggableInfo(store: Store, posInfo: PosInfo): DraggableIn
   const { rowKey } = rawData[index];
   const cells = fromArray(posInfo.container!.querySelectorAll(`[data-row-key="${rowKey}"]`));
 
-  return { row: createFloatingDraggableRow(offsetTop, cells), rowKey };
+  return {
+    row: createFloatingDraggableRow(offsetTop, cells, column.treeColumnName),
+    rowKey,
+    line: createFloatingLine(),
+  };
 }
 
 export function getMovedPosAndIndex(store: Store, { pageY, top, scrollTop }: PosInfo) {
-  const { rowCoords, dimension } = store;
+  const { rowCoords, dimension, column } = store;
+  const { headerHeight } = dimension;
   const offsetTop = pageY - top + scrollTop;
   let index = findOffsetIndex(rowCoords.offsets, offsetTop);
 
-  if (offsetTop - rowCoords.offsets[index] > rowCoords.heights[index] * EXCEED_RATIO) {
-    index += 1;
+  if (!column.treeColumnName) {
+    if (offsetTop - rowCoords.offsets[index] > rowCoords.heights[index] * EXCEED_RATIO) {
+      index += 1;
+    }
   }
 
-  return { offsetTop: offsetTop + dimension.headerHeight, index };
+  return {
+    offsetTop: offsetTop - scrollTop + headerHeight,
+    index,
+    height: rowCoords.offsets[index] + headerHeight,
+  };
+}
+
+export function createFloatingLine() {
+  const line = document.createElement('div');
+
+  line.style.position = 'absolute';
+  line.style.height = '1px';
+  line.style.width = 'calc(100% - 17px)';
+  line.style.background = '#00a9ff';
+
+  return line;
 }

--- a/packages/toast-ui.grid/src/query/draggable.ts
+++ b/packages/toast-ui.grid/src/query/draggable.ts
@@ -32,11 +32,12 @@ function createRow(height: string) {
 }
 
 function createCells(cell: Element) {
+  const childLen = cell.childNodes.length;
   const el = document.createElement('div');
   el.className = cls('floating-cell');
   el.style.width = window.getComputedStyle(cell).width;
 
-  for (let i = 0; i < cell.childNodes.length; i += 1) {
+  for (let i = 0; i < childLen; i += 1) {
     // the cell is not complex structure, so there is no the performance problem
     el.appendChild(cell.childNodes[i].cloneNode(true));
   }

--- a/packages/toast-ui.grid/src/query/draggable.ts
+++ b/packages/toast-ui.grid/src/query/draggable.ts
@@ -135,10 +135,7 @@ export function getMovedPosAndIndex(store: Store, { pageY, top, scrollTop }: Pos
 export function createFloatingLine(scrollYWidth: number) {
   const line = document.createElement('div');
 
-  line.style.position = 'absolute';
-  line.style.height = '1px';
-  line.style.background = '#00a9ff';
-  line.style.display = 'none';
+  line.className = cls('floating-line');
   line.style.width = `calc(100% - ${scrollYWidth}px)`;
 
   return line;

--- a/packages/toast-ui.grid/src/query/tree.ts
+++ b/packages/toast-ui.grid/src/query/tree.ts
@@ -114,7 +114,7 @@ export function isHidden(row: Row) {
 export function isLeaf(row: Row) {
   const { tree } = row._attributes;
 
-  return !!tree && !tree.childRowKeys.length;
+  return !!tree && !tree.childRowKeys.length && !!row._leaf;
 }
 
 export function isExpanded(row: Row) {

--- a/packages/toast-ui.grid/src/query/tree.ts
+++ b/packages/toast-ui.grid/src/query/tree.ts
@@ -114,7 +114,7 @@ export function isHidden(row: Row) {
 export function isLeaf(row: Row) {
   const { tree } = row._attributes;
 
-  return !!tree && !tree.childRowKeys.length && isUndefined(tree.expanded);
+  return !!tree && !tree.childRowKeys.length;
 }
 
 export function isExpanded(row: Row) {

--- a/packages/toast-ui.grid/src/query/tree.ts
+++ b/packages/toast-ui.grid/src/query/tree.ts
@@ -105,16 +105,16 @@ export function getChildRowKeys(row: Row) {
   return tree ? tree.childRowKeys.slice() : [];
 }
 
-export function isHidden(row: Row) {
-  const { tree } = row._attributes;
+export function isHidden({ _attributes }: Row) {
+  const { tree } = _attributes;
 
   return !!(tree && tree.hidden);
 }
 
-export function isLeaf(row: Row) {
-  const { tree } = row._attributes;
+export function isLeaf({ _attributes, _leaf }: Row) {
+  const { tree } = _attributes;
 
-  return !!tree && !tree.childRowKeys.length && !!row._leaf;
+  return !!tree && !tree.childRowKeys.length && !!_leaf;
 }
 
 export function isExpanded(row: Row) {

--- a/packages/toast-ui.grid/src/store/column.ts
+++ b/packages/toast-ui.grid/src/store/column.ts
@@ -386,7 +386,7 @@ interface ColumnOption {
   valign: VAlignType;
   columnHeaders: OptColumnHeaderInfo[];
   disabled: boolean;
-  draggableRow: boolean;
+  draggable: boolean;
 }
 
 export function create({
@@ -401,7 +401,7 @@ export function create({
   valign,
   columnHeaders,
   disabled,
-  draggableRow,
+  draggable,
 }: ColumnOption) {
   const relationColumns = columns.reduce((acc: string[], { relations }) => {
     acc = acc.concat(createRelationColumns(relations || []));
@@ -411,7 +411,7 @@ export function create({
   const columnHeaderInfo = { columnHeaders, align, valign };
   const rowHeaderInfos = [];
 
-  if (draggableRow) {
+  if (draggable) {
     let rowHeaderColumn: OptRowHeader | null = null;
     const index = findIndex(
       (rowHeader) =>

--- a/packages/toast-ui.grid/src/store/column.ts
+++ b/packages/toast-ui.grid/src/store/column.ts
@@ -8,6 +8,7 @@ import {
   OptComplexColumnInfo,
   Dictionary,
   OptFilter,
+  OptRowHeaderColumn,
 } from '@t/options';
 import {
   ColumnOptions,
@@ -37,6 +38,7 @@ import {
   findProp,
   uniq,
   isEmpty,
+  findIndex,
 } from '../helper/common';
 import { DefaultRenderer } from '../renderer/default';
 import { editorMap } from '../editor/manager';
@@ -49,6 +51,7 @@ const COLUMN = 50;
 const rowHeadersMap = {
   rowNum: '_number',
   checkbox: '_checked',
+  draggable: '_draggable',
 };
 
 export function validateRelationColumn(columnInfos: ColumnInfo[]) {
@@ -346,7 +349,11 @@ function createComplexColumnHeaders(
   });
 }
 
-function createDraggableRowHeader() {
+function createDraggableRowHeader(rowHeaderColumn: OptRowHeader | null) {
+  const renderer = isObject(rowHeaderColumn)
+    ? rowHeaderColumn.renderer
+    : { type: RowHeaderDraggableRenderer };
+
   const draggebleColumn: ColumnInfo = {
     name: '_draggable',
     header: '',
@@ -354,7 +361,7 @@ function createDraggableRowHeader() {
     resizable: false,
     align: 'center',
     valign: 'middle',
-    renderer: createRendererOptions({ type: RowHeaderDraggableRenderer }),
+    renderer: createRendererOptions(renderer),
     baseWidth: ROW_HEADER,
     minWidth: ROW_HEADER,
     fixedWidth: true,
@@ -402,13 +409,25 @@ export function create({
   }, []);
 
   const columnHeaderInfo = { columnHeaders, align, valign };
-  const rowHeaderInfos = rowHeaders.map((rowHeader) =>
-    createRowHeader(rowHeader, columnHeaderInfo)
-  );
+  const rowHeaderInfos = [];
 
   if (draggableRow) {
-    rowHeaderInfos.unshift(createDraggableRowHeader());
+    let rowHeaderColumn: OptRowHeader | null = null;
+    const index = findIndex(
+      (rowHeader) =>
+        (isString(rowHeader) && rowHeader === 'draggable') ||
+        (rowHeader as OptRowHeaderColumn).type === 'draggable',
+      rowHeaders
+    );
+    if (index !== -1) {
+      [rowHeaderColumn] = rowHeaders.splice(index, 1);
+    }
+    rowHeaderInfos.push(createDraggableRowHeader(rowHeaderColumn));
   }
+
+  rowHeaders.forEach((rowHeader) =>
+    rowHeaderInfos.push(createRowHeader(rowHeader, columnHeaderInfo))
+  );
 
   const columnInfos = columns.map((column) =>
     createColumn(

--- a/packages/toast-ui.grid/src/store/column.ts
+++ b/packages/toast-ui.grid/src/store/column.ts
@@ -354,7 +354,7 @@ function createDraggableRowHeader(rowHeaderColumn: OptRowHeader | null) {
     ? rowHeaderColumn.renderer
     : { type: RowHeaderDraggableRenderer };
 
-  const draggebleColumn: ColumnInfo = {
+  const draggableColumn: ColumnInfo = {
     name: '_draggable',
     header: '',
     hidden: false,
@@ -371,7 +371,7 @@ function createDraggableRowHeader(rowHeaderColumn: OptRowHeader | null) {
     headerVAlign: 'middle',
   };
 
-  return draggebleColumn;
+  return draggableColumn;
 }
 
 interface ColumnOption {

--- a/packages/toast-ui.grid/src/store/create.ts
+++ b/packages/toast-ui.grid/src/store/create.ts
@@ -42,7 +42,7 @@ export function createStore(id: number, options: OptGrid): Store {
     treeColumnOptions = { name: '' },
     header = {},
     disabled = false,
-    draggableRow = false,
+    draggable = false,
   } = options;
   const { frozenBorderWidth } = columnOptions;
   const { height: summaryHeight, position: summaryPosition } = summaryOptions;
@@ -65,7 +65,7 @@ export function createStore(id: number, options: OptGrid): Store {
     valign,
     columnHeaders,
     disabled,
-    draggableRow,
+    draggable,
   });
   const data = createData({
     data: Array.isArray(options.data) ? options.data : [],

--- a/packages/toast-ui.grid/src/store/helper/tree.ts
+++ b/packages/toast-ui.grid/src/store/helper/tree.ts
@@ -95,9 +95,7 @@ export function createTreeRawRow(
 
   const tree = {
     ...defaultAttributes,
-    ...((Array.isArray(row._children) || childRowKeys.length) && {
-      expanded: !!row._attributes!.expanded,
-    }),
+    expanded: !!row._attributes!.expanded,
   };
 
   rawRow._attributes.tree = lazyObservable ? tree : observable(tree);

--- a/packages/toast-ui.grid/src/store/helper/tree.ts
+++ b/packages/toast-ui.grid/src/store/helper/tree.ts
@@ -4,7 +4,7 @@ import { Column } from '../../../types/store/column';
 import { createRawRow } from '../data';
 import { isExpanded, getDepth, isLeaf, isHidden } from '../../query/tree';
 import { observable, observe } from '../../helper/observable';
-import { includes, isUndefined } from '../../helper/common';
+import { includes, isUndefined, someProp } from '../../helper/common';
 import { TREE_INDENT_WIDTH } from '../../helper/constant';
 
 interface TreeDataOption {
@@ -31,20 +31,30 @@ function generateTreeRowKey() {
   return treeRowKey;
 }
 
-function addChildRowKey(row: Row, rowKey: RowKey) {
+function addChildRowKey(row: Row, childRow: Row) {
   const { tree } = row._attributes;
+  const { rowKey } = childRow;
 
   if (tree && !includes(tree.childRowKeys, rowKey)) {
     tree.childRowKeys.push(rowKey);
   }
+  if (!someProp('rowKey', rowKey, row._children!)) {
+    row._children!.push(childRow);
+  }
+  row._isLeaf = false;
 }
 
-function insertChildRowKey(row: Row, rowKey: RowKey, offset: number) {
+function insertChildRowKey(row: Row, childRow: Row, offset: number) {
   const { tree } = row._attributes;
+  const { rowKey } = childRow;
 
   if (tree && !includes(tree.childRowKeys, rowKey)) {
     tree.childRowKeys.splice(offset, 0, rowKey);
   }
+  if (!someProp('rowKey', rowKey, row._children!)) {
+    row._children!.splice(offset, 0, childRow);
+  }
+  row._isLeaf = false;
 }
 
 function getTreeCellInfo(rawData: Row[], row: Row, useIcon?: boolean) {
@@ -71,6 +81,11 @@ export function createTreeRawRow(
     childRowKeys = row._attributes.tree.childRowKeys as RowKey[];
   }
   const { keyColumnName, offset, lazyObservable = false, disabled = false } = options;
+
+  if (!row._children) {
+    row._children = [];
+    row._leaf = true;
+  }
   // generate new tree rowKey when row doesn't have rowKey
   const targetTreeRowKey = isUndefined(row.rowKey) ? generateTreeRowKey() : Number(row.rowKey);
   const rawRow = createRawRow(id, row, targetTreeRowKey, column, {
@@ -78,7 +93,6 @@ export function createTreeRawRow(
     lazyObservable,
     disabled,
   });
-  const { rowKey } = rawRow;
   const defaultAttributes = {
     parentRowKey: parentRow ? parentRow.rowKey : null,
     childRowKeys,
@@ -87,15 +101,15 @@ export function createTreeRawRow(
 
   if (parentRow) {
     if (!isUndefined(offset)) {
-      insertChildRowKey(parentRow, rowKey, offset);
+      insertChildRowKey(parentRow, rawRow, offset);
     } else {
-      addChildRowKey(parentRow, rowKey);
+      addChildRowKey(parentRow, rawRow);
     }
   }
 
   const tree = {
     ...defaultAttributes,
-    expanded: !!row._attributes!.expanded,
+    expanded: row._attributes!.expanded,
   };
 
   rawRow._attributes.tree = lazyObservable ? tree : observable(tree);

--- a/packages/toast-ui.grid/src/view/bodyArea.tsx
+++ b/packages/toast-ui.grid/src/view/bodyArea.tsx
@@ -139,7 +139,7 @@ class BodyAreaComp extends Component<Props> {
 
       row.style.top = `${offsetTop}px`;
 
-      const gridEvent = new GridEvent({ rowKey, currentRowKey: this.movedIndexInfo?.rowKey });
+      const gridEvent = new GridEvent({ rowKey, currentRowKey: rowKeyToMove });
       /**
        * Occurs when dragging the row
        * @event Grid#drag

--- a/packages/toast-ui.grid/src/view/bodyArea.tsx
+++ b/packages/toast-ui.grid/src/view/bodyArea.tsx
@@ -296,7 +296,7 @@ class BodyAreaComp extends Component<Props> {
 
       if (!gridEvent.isStopped()) {
         if (hasTreeColumn) {
-          this.props.dispatch('moveTreeRow', rowKey, index, !!appended);
+          this.props.dispatch('moveTreeRow', rowKey, index, { appended: !!appended });
         } else {
           this.props.dispatch('moveRow', rowKey, index);
         }

--- a/packages/toast-ui.grid/src/view/bodyArea.tsx
+++ b/packages/toast-ui.grid/src/view/bodyArea.tsx
@@ -12,6 +12,7 @@ import {
   hasClass,
   isDatePickerElement,
   findParent,
+  getCellAddress,
 } from '../helper/dom';
 import { DispatchProps } from '../dispatch/create';
 import { connect } from './hoc';
@@ -70,11 +71,10 @@ const PROPS_FOR_UPDATE: (keyof StoreProps)[] = [
 ];
 // Minimum distance (pixel) to detect if user wants to drag when moving mouse with button pressed.
 const MIN_DISTANCE_FOR_DRAG = 10;
-
 const ADDITIONAL_RANGE = 3;
-
 const DRAGGING_CLASS = 'dragging';
 const PARENT_CELL_CLASS = 'parent-cell';
+const DRAGGABLE_COLUMN_NAME = '_draggable';
 
 class BodyAreaComp extends Component<Props> {
   private el?: HTMLElement;
@@ -229,7 +229,7 @@ class BodyAreaComp extends Component<Props> {
     const { top, left } = el.getBoundingClientRect();
     this.boundingRect = { top, left };
 
-    if (findParent(targetElement, 'row-header-draggable')) {
+    if (getCellAddress(targetElement)?.columnName === DRAGGABLE_COLUMN_NAME) {
       this.startToDragRow(pageY, top, scrollTop);
       return;
     }

--- a/packages/toast-ui.grid/src/view/bodyArea.tsx
+++ b/packages/toast-ui.grid/src/view/bodyArea.tsx
@@ -337,13 +337,13 @@ class BodyAreaComp extends Component<Props> {
     document.removeEventListener('selectstart', this.handleSelectStart);
   };
 
-  public shouldComponentUpdate(nextProps: Props) {
+  shouldComponentUpdate(nextProps: Props) {
     const currProps = this.props;
 
     return some((propName) => nextProps[propName] !== currProps[propName], PROPS_FOR_UPDATE);
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  componentWillReceiveProps(nextProps: Props) {
     const { scrollTop, scrollLeft } = nextProps;
 
     this.el!.scrollTop = scrollTop;

--- a/packages/toast-ui.grid/src/view/bodyArea.tsx
+++ b/packages/toast-ui.grid/src/view/bodyArea.tsx
@@ -139,13 +139,13 @@ class BodyAreaComp extends Component<Props> {
 
       row.style.top = `${offsetTop}px`;
 
-      const gridEvent = new GridEvent({ rowKey, currentRowKey: rowKeyToMove });
+      const gridEvent = new GridEvent({ rowKey, targetRowKey: rowKeyToMove });
       /**
        * Occurs when dragging the row
        * @event Grid#drag
        * @property {Grid} instance - Current grid instance
        * @property {RowKey} rowKey - The rowKey of the dragging row
-       * @property {RowKey} currentRowKey - The rowKey of the row at current dragging position
+       * @property {RowKey} targetRowKey - The rowKey of the row at current dragging position
        */
       this.props.eventBus.trigger('drag', gridEvent);
 
@@ -282,15 +282,15 @@ class BodyAreaComp extends Component<Props> {
     const { rowKey } = this.draggableInfo!;
 
     if (this.movedIndexInfo) {
-      const { index, appended } = this.movedIndexInfo;
+      const { index, appended, rowKey: targetRowKey } = this.movedIndexInfo;
 
-      const gridEvent = new GridEvent({ rowKey, currentRowKey: this.movedIndexInfo.rowKey });
+      const gridEvent = new GridEvent({ rowKey, targetRowKey });
       /**
        * Occurs when droppring the row
        * @event Grid#drop
        * @property {Grid} instance - Current grid instance
        * @property {RowKey} rowKey - The rowKey of the dragging row
-       * @property {RowKey} currentRowKey - The rowKey of the row at current dragging position
+       * @property {RowKey} targetRowKey - The rowKey of the row at current dragging position
        */
       this.props.eventBus.trigger('drop', gridEvent);
 

--- a/packages/toast-ui.grid/types/event/index.d.ts
+++ b/packages/toast-ui.grid/types/event/index.d.ts
@@ -38,7 +38,7 @@ export interface GridEventProps {
   origin?: Origin;
   changes?: CellChange[];
   floatingRow?: HTMLElement;
-  currentRowKey?: RowKey | null;
+  targetRowKey?: RowKey | null;
 }
 
 export class TuiGridEvent {

--- a/packages/toast-ui.grid/types/event/index.d.ts
+++ b/packages/toast-ui.grid/types/event/index.d.ts
@@ -37,6 +37,8 @@ export interface GridEventProps {
   page?: number;
   origin?: Origin;
   changes?: CellChange[];
+  floatingRow?: HTMLElement;
+  currentRowKey?: RowKey | null;;
 }
 
 export class TuiGridEvent {

--- a/packages/toast-ui.grid/types/event/index.d.ts
+++ b/packages/toast-ui.grid/types/event/index.d.ts
@@ -38,7 +38,7 @@ export interface GridEventProps {
   origin?: Origin;
   changes?: CellChange[];
   floatingRow?: HTMLElement;
-  currentRowKey?: RowKey | null;;
+  currentRowKey?: RowKey | null;
 }
 
 export class TuiGridEvent {

--- a/packages/toast-ui.grid/types/index.d.ts
+++ b/packages/toast-ui.grid/types/index.d.ts
@@ -20,6 +20,7 @@ import {
   OptRow,
   OptColumn,
   ResetOptions,
+  OptMoveRow,
 } from './options';
 import {
   ModifiedRowsOptions,
@@ -262,7 +263,7 @@ declare namespace tui {
 
     public setRow(rowKey: RowKey, row: OptRow): void;
 
-    public moveRow(rowKey: RowKey, targetIndex: number): void;
+    public moveRow(rowKey: RowKey, targetIndex: number, options: OptMoveRow): void;
 
     public setRequestParams(params: Dictionary<any>): void;
 

--- a/packages/toast-ui.grid/types/options.d.ts
+++ b/packages/toast-ui.grid/types/options.d.ts
@@ -109,7 +109,7 @@ export interface OptGrid {
   onGridMounted?: GridEventListener;
   onGridUpdated?: GridEventListener;
   onGridBeforeDestroy?: GridEventListener;
-  draggableRow?: boolean;
+  draggable?: boolean;
 }
 
 export interface OptRow {

--- a/packages/toast-ui.grid/types/options.d.ts
+++ b/packages/toast-ui.grid/types/options.d.ts
@@ -140,6 +140,10 @@ export interface OptAppendTreeRow {
   focus?: boolean;
 }
 
+export interface OptMoveRow {
+  appended?: boolean;
+}
+
 export interface OptTree {
   name: string;
   useIcon?: boolean;

--- a/packages/toast-ui.grid/types/options.d.ts
+++ b/packages/toast-ui.grid/types/options.d.ts
@@ -118,7 +118,7 @@ export interface OptRow {
 export interface OptAppendRow {
   at?: number;
   focus?: boolean;
-  parentRowKey?: RowKey;
+  parentRowKey?: RowKey | null;
   extendPrevRowSpan?: boolean;
 }
 
@@ -132,7 +132,7 @@ export interface OptRemoveRow {
 }
 
 export interface OptAppendTreeRow {
-  parentRowKey?: RowKey;
+  parentRowKey?: RowKey | null;
   offset?: number;
   focus?: boolean;
 }

--- a/packages/toast-ui.grid/types/options.d.ts
+++ b/packages/toast-ui.grid/types/options.d.ts
@@ -73,7 +73,10 @@ export type GridEventName =
   | 'beforePageMove'
   | 'afterPageMove'
   | 'beforeChange'
-  | 'afterChange';
+  | 'afterChange'
+  | 'dragStart'
+  | 'drag'
+  | 'drop';
 export type GridEventListener = (gridEvent: TuiGridEvent) => void;
 
 export interface OptGrid {

--- a/packages/toast-ui.grid/types/store/column.d.ts
+++ b/packages/toast-ui.grid/types/store/column.d.ts
@@ -12,7 +12,7 @@ export type CustomValue =
 export type VAlignType = 'top' | 'middle' | 'bottom';
 export type AlignType = 'left' | 'center' | 'right';
 export type Formatter = ((props: FormatterProps) => string) | string;
-export type RowHeaderType = 'rowNum' | 'checkbox';
+export type RowHeaderType = 'rowNum' | 'checkbox' | 'draggable';
 export type SortingType = 'asc' | 'desc';
 export type ErrorCode =
   | 'REQUIRED'

--- a/packages/toast-ui.grid/types/store/data.d.ts
+++ b/packages/toast-ui.grid/types/store/data.d.ts
@@ -18,6 +18,7 @@ export type Row = Dictionary<CellValue> & {
   _relationListItemMap: Dictionary<ListItem[]>;
   _disabledPriority: DisabledPriority;
   _children?: Row[];
+  _leaf?: boolean;
 };
 export type RowSpanAttributeValue = RowSpanAttribute[keyof RowSpanAttribute];
 export type DisabledPriority = Dictionary<'ROW' | 'COLUMN'>;
@@ -34,7 +35,7 @@ export interface RawRowOptions {
 export interface TreeRowInfo {
   parentRowKey: RowKey | null;
   childRowKeys: RowKey[];
-  expanded?: boolean;
+  expanded?: boolean | null;
   hidden: boolean;
 }
 

--- a/packages/toast-ui.grid/types/store/data.d.ts
+++ b/packages/toast-ui.grid/types/store/data.d.ts
@@ -35,7 +35,7 @@ export interface RawRowOptions {
 export interface TreeRowInfo {
   parentRowKey: RowKey | null;
   childRowKeys: RowKey[];
-  expanded?: boolean | null;
+  expanded?: boolean;
   hidden: boolean;
 }
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
we added move tree row functionality by dragging or `moveRow` API.

#### 1. D&D operation
```js
const grid = new tui.Grid({
  el: document.getElementById('grid'),
  data: treeData,
  draggable: true,
  treeColumnOptions: {
    name: 'name',
    useCascadingCheckbox: true
  },
  // ...
}
```
* move to an another index
![2021-04-21 14-52-42 2021-04-21 14_53_18](https://user-images.githubusercontent.com/37766175/115642231-8989f700-a355-11eb-878c-738127399e31.gif)
* append to another node
![2021-04-21 14-53-34 2021-04-21 14_53_53](https://user-images.githubusercontent.com/37766175/115642247-93135f00-a355-11eb-9c02-3af4cef31060.gif)

#### 2. drag row header customizing
The user can customize the `draggable` row header column through existing `rowHeaders` option
```js
class DraggableRenderer {
  constructor(props) {
    const el = document.createElement('span');
    el.innerHTML = `😀`;
    el.style.cursor = 'pointer'
    this.el = el;
  }

  getElement() {
    return this.el;
  }

  render(props) {
    this.el.innerHTML = `😀`;
  }
}

const grid = new Grid({
  el: document.getElementById('grid'),
  data: treeData,
  rowHeaders: [
    {
      type: 'draggable',
      renderer: {
        type: DraggableRenderer
      }
    },
  ],
  bodyHeight: 500,
  draggable: true,
  treeColumnOptions: {
    name: 'name',
    useCascadingCheckbox: true
  },
  // ...
}
```
![2021-04-22 10-34-31 2021-04-22 10_34_44](https://user-images.githubusercontent.com/37766175/115642688-60b63180-a356-11eb-871a-754e8940c72b.gif)

#### 3. `moveRow` API
We added the option in `moveRow` API for tree data.
The option is configured with `appended` property which has boolean value. This property for only tree data and deciedes whether the row is appended to other row as the child.
```ts
interface OptMoveRow {
  appended?: boolean
}
public moveRow(rowKey: RowKey, targetIndex: number, options: OptMoveRow): void;
```

#### 4. custom event(`dragStart`, `drag`, `drop`)
- `dragStart`: Drag to start the movement of the row (only occurs if the `dragable` option is enabled)
  - **rowKey**: dragging row's rowkey
  - **floatingRow**: floating row DOM element for customizing.
- `drag`: Dragging to move row (only occurs if the `dragable` option is enabled)
  - **rowKey**: dragging row's rowkey
  - **targetRowKey**: The rowKey to move
- `drop`: When the drag is over and the row movement is complete. (only occurs if the `dragable` option is enabled)
  - **rowKey**: dragging row's rowkey
  - **targetRowKey**: The rowKey to move


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
