### PR TITLE
fix: add i18n for filter select option

### DIFF
--- a/packages/toast-ui.grid/src/helper/filter.ts
+++ b/packages/toast-ui.grid/src/helper/filter.ts
@@ -7,6 +7,7 @@ import {
 } from '@t/store/filterLayerState';
 import { CellValue } from '@t/store/data';
 import { isString, endsWith, startsWith } from './common';
+import i18n from '../i18n';
 
 interface FilterSelectOption {
   number: { [key in NumberFilterCode]: string };
@@ -14,31 +15,38 @@ interface FilterSelectOption {
   date: { [key in DateFilterCode]: string };
 }
 
-export const filterSelectOption: FilterSelectOption = {
-  number: {
-    eq: '=',
-    lt: '<',
-    gt: '>',
-    lte: '<=',
-    gte: '>=',
-    ne: '!=',
-  },
-  text: {
-    contain: 'Contains',
-    eq: 'Equals',
-    ne: 'Not equals',
-    start: 'Starts with',
-    end: 'Ends with',
-  },
-  date: {
-    eq: 'Equals',
-    ne: 'Not equals',
-    after: 'After',
-    afterEq: 'After or Equal',
-    before: 'Before',
-    beforeEq: 'Before or Equal',
-  },
-};
+let filterSelectOption: FilterSelectOption;
+
+export function createFilterSelectOption(): FilterSelectOption {
+  if (!filterSelectOption) {
+    filterSelectOption = {
+      number: {
+        eq: '=',
+        lt: '<',
+        gt: '>',
+        lte: '<=',
+        gte: '>=',
+        ne: '!=',
+      },
+      text: {
+        contain: i18n.get('filter.contains'),
+        eq: i18n.get('filter.eq'),
+        ne: i18n.get('filter.ne'),
+        start: i18n.get('filter.start'),
+        end: i18n.get('filter.end'),
+      },
+      date: {
+        eq: i18n.get('filter.eq'),
+        ne: i18n.get('filter.ne'),
+        after: i18n.get('filter.after'),
+        afterEq: i18n.get('filter.afterEq'),
+        before: i18n.get('filter.before'),
+        beforeEq: i18n.get('filter.beforeEq'),
+      },
+    };
+  }
+  return filterSelectOption;
+}
 
 export function getUnixTime(value: CellValue) {
   return parseInt((new Date(String(value)).getTime() / 1000).toFixed(0), 10);

--- a/packages/toast-ui.grid/src/i18n/index.ts
+++ b/packages/toast-ui.grid/src/i18n/index.ts
@@ -71,7 +71,6 @@ const messages: OptI18nLanguage = {
       beforeEq: 'Before or Equal',
       apply: 'Apply',
       clear: 'Clear',
-
       selectAll: 'Select All',
     },
   },

--- a/packages/toast-ui.grid/src/i18n/index.ts
+++ b/packages/toast-ui.grid/src/i18n/index.ts
@@ -26,6 +26,17 @@ const messages: OptI18nLanguage = {
       noDataToModify: 'No data to modify.',
       failResponse: 'An error occurred while requesting data.\nPlease try again.',
     },
+    filter: {
+      contains: 'Contains',
+      eq: 'Equals',
+      ne: 'Not equals',
+      start: 'Starts with',
+      end: 'Ends with',
+      after: 'After',
+      afterEq: 'After or Equal',
+      before: 'Before',
+      beforeEq: 'Before or Equal',
+    },
   },
   ko: {
     display: {
@@ -44,6 +55,17 @@ const messages: OptI18nLanguage = {
       noDataToDelete: '삭제할 데이터가 없습니다.',
       noDataToModify: '처리할 데이터가 없습니다.',
       failResponse: '데이터 요청 중에 에러가 발생하였습니다.\n다시 시도하여 주시기 바랍니다.',
+    },
+    filter: {
+      contains: 'Contains',
+      eq: 'Equals',
+      ne: 'Not equals',
+      start: 'Starts with',
+      end: 'Ends with',
+      after: 'After',
+      afterEq: 'After or Equal',
+      before: 'Before',
+      beforeEq: 'Before or Equal',
     },
   },
 };

--- a/packages/toast-ui.grid/src/i18n/index.ts
+++ b/packages/toast-ui.grid/src/i18n/index.ts
@@ -36,6 +36,9 @@ const messages: OptI18nLanguage = {
       afterEq: 'After or Equal',
       before: 'Before',
       beforeEq: 'Before or Equal',
+      apply: 'Apply',
+      clear: 'Clear',
+      selectAll: 'Select All',
     },
   },
   ko: {
@@ -66,6 +69,10 @@ const messages: OptI18nLanguage = {
       afterEq: 'After or Equal',
       before: 'Before',
       beforeEq: 'Before or Equal',
+      apply: 'Apply',
+      clear: 'Clear',
+
+      selectAll: 'Select All',
     },
   },
 };

--- a/packages/toast-ui.grid/src/view/datePickerFilter.tsx
+++ b/packages/toast-ui.grid/src/view/datePickerFilter.tsx
@@ -13,7 +13,7 @@ import { DispatchProps } from '../dispatch/create';
 import Grid from '../grid';
 import { getInstance } from '../instance';
 import { cls } from '../helper/dom';
-import { filterSelectOption } from '../helper/filter';
+import { createFilterSelectOption } from '../helper/filter';
 import { debounce, deepMergedCopy, isString } from '../helper/common';
 import { keyNameMap, isNonPrintableKey, KeyNameMap } from '../helper/keyboard';
 import { FILTER_DEBOUNCE_TIME } from '../helper/constant';
@@ -132,7 +132,8 @@ class DatePickerFilterComp extends Component<Props> {
     const { columnInfo } = this.props;
     const { options } = columnInfo.filter!;
     const showIcon = !(options && options.showIcon === false);
-    const selectOption = filterSelectOption.date;
+    const filterSelectOptions = createFilterSelectOption();
+    const selectOption = filterSelectOptions.date;
     const { value, code } = this.getPreviousValue();
 
     return (

--- a/packages/toast-ui.grid/src/view/filterLayerInner.tsx
+++ b/packages/toast-ui.grid/src/view/filterLayerInner.tsx
@@ -9,6 +9,7 @@ import { DatePickerFilter } from './datePickerFilter';
 import { FilterOperator } from './filterOperator';
 import { SelectFilter } from './selectFilter';
 import { some } from '../helper/common';
+import i18n from '../i18n';
 
 interface StoreProps {
   filters: Filter[] | null;
@@ -86,7 +87,7 @@ export class FilterLayerInnerComp extends Component<Props> {
                 dispatch('clearActiveFilterState');
               }}
             >
-              Clear
+              {i18n.get('filter.clear')}
             </button>
           )}
           {showApplyBtn && (
@@ -96,7 +97,7 @@ export class FilterLayerInnerComp extends Component<Props> {
                 dispatch('applyActiveFilterState');
               }}
             >
-              Apply
+              {i18n.get('filter.apply')}
             </button>
           )}
         </div>

--- a/packages/toast-ui.grid/src/view/selectFilter.tsx
+++ b/packages/toast-ui.grid/src/view/selectFilter.tsx
@@ -10,6 +10,7 @@ import { cls } from '../helper/dom';
 import { some, debounce } from '../helper/common';
 import { getUniqColumnData } from '../query/data';
 import { FILTER_DEBOUNCE_TIME } from '../helper/constant';
+import i18n from '../i18n';
 
 interface ColumnData {
   value: CellValue;
@@ -76,7 +77,7 @@ class SelectFilterComp extends Component<Props> {
               onChange={this.toggleAllColumnCheckbox}
               checked={isAllSelected}
             />
-            <span>Select All</span>
+            <span>{i18n.get('filter.selectAll')}</span>
           </label>
         </li>
         <ul className={cls('filter-list')}>

--- a/packages/toast-ui.grid/src/view/textFilter.tsx
+++ b/packages/toast-ui.grid/src/view/textFilter.tsx
@@ -9,7 +9,7 @@ import { ColumnInfo } from '@t/store/column';
 import { connect } from './hoc';
 import { DispatchProps } from '../dispatch/create';
 import { cls } from '../helper/dom';
-import { filterSelectOption } from '../helper/filter';
+import { createFilterSelectOption } from '../helper/filter';
 import { debounce } from '../helper/common';
 import { keyNameMap, isNonPrintableKey, KeyNameMap } from '../helper/keyboard';
 import { FILTER_DEBOUNCE_TIME } from '../helper/constant';
@@ -74,7 +74,8 @@ class TextFilterComp extends Component<Props> {
   public render() {
     const { columnInfo } = this.props;
     const { code, value } = this.getPreviousValue();
-    const selectOption = filterSelectOption[
+    const filterSelectOptions = createFilterSelectOption();
+    const selectOption = filterSelectOptions[
       columnInfo.filter!.type as 'number' | 'text'
     ] as SelectOption;
 

--- a/packages/toast-ui.grid/types/options.d.ts
+++ b/packages/toast-ui.grid/types/options.d.ts
@@ -448,6 +448,9 @@ export interface OptI18nData {
     afterEq?: string;
     before?: string;
     beforeEq?: string;
+    apply?: string;
+    clear?: string;
+    selectAll?: string;
   };
 }
 

--- a/packages/toast-ui.grid/types/options.d.ts
+++ b/packages/toast-ui.grid/types/options.d.ts
@@ -438,6 +438,17 @@ export interface OptI18nData {
     noDataToModify?: string;
     failResponse?: string;
   };
+  filter?: {
+    contains?: string;
+    eq?: string;
+    ne?: string;
+    start?: string;
+    end?: string;
+    after?: string;
+    afterEq?: string;
+    before?: string;
+    beforeEq?: string;
+  };
 }
 
 export interface SortStateResetOption {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* added i18n for filter select option
```js
const messages: OptI18nLanguage = {
  en: {
    // ...
    filter: {
      contains: 'Contains',
      eq: 'Equals',
      ne: 'Not equals',
      start: 'Starts with',
      end: 'Ends with',
      after: 'After',
      afterEq: 'After or Equal',
      before: 'Before',
      beforeEq: 'Before or Equal',
    },
  },
}
```
* related issue(#1234)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
