### PR TITLE
fix: cannot move tree node to last when last node has children

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/tree.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/tree.spec.ts
@@ -1254,6 +1254,36 @@ describe('move tree row', () => {
       appended: true,
     });
   });
+
+  it('should move node to the last regardless of the children properly', () => {
+    // move to last in case of having children
+    cy.gridInstance().invoke('moveRow', 2, 7);
+
+    cy.getRsideBody().should('have.cellData', [
+      ['foo'],
+      ['bar'],
+      ['foo_2'],
+      ['bar_2'],
+      ['baz_2'],
+      ['baz'],
+      ['qux'],
+      ['quxx'],
+    ]);
+
+    // move to last in case of leaf node(baz_2)
+    cy.gridInstance().invoke('moveRow', 7, 7);
+
+    cy.getRsideBody().should('have.cellData', [
+      ['foo'],
+      ['bar'],
+      ['foo_2'],
+      ['bar_2'],
+      ['baz'],
+      ['qux'],
+      ['quxx'],
+      ['baz_2'],
+    ]);
+  });
 });
 
 it(`should move the row to with complicated data`, () => {

--- a/packages/toast-ui.grid/src/dispatch/tree.ts
+++ b/packages/toast-ui.grid/src/dispatch/tree.ts
@@ -288,8 +288,7 @@ export function removeExpandedAttr(row: Row) {
   const { tree } = row._attributes;
 
   if (tree) {
-    delete tree.expanded;
-    notify(tree, 'expanded');
+    tree.expanded = false;
   }
 }
 
@@ -449,7 +448,7 @@ export function moveTreeRow(
     if (options.appended) {
       appendTreeRow(store, originRow, { parentRowKey: targetRow.rowKey });
     } else {
-      const { parentRowKey } = targetRow._attributes.tree!;
+      let { parentRowKey } = targetRow._attributes.tree!;
       const parentIndex = findIndexByRowKey(data, column, id, parentRowKey);
       let offset = targetIndex > currentIndex ? targetIndex - (childRows.length + 1) : targetIndex;
 
@@ -462,7 +461,8 @@ export function moveTreeRow(
 
       // to resolve the index for moving last index
       if (options.moveToLast) {
-        offset += 1;
+        parentRowKey = null;
+        offset = rawData.length;
       }
       appendTreeRow(store, originRow, { parentRowKey, offset });
     }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* fixed that cannot move tree node to last when last node has children
![GIF 2021-05-21 오전 11-18-54](https://user-images.githubusercontent.com/37766175/119283183-328a8100-bc77-11eb-9e0e-4178cf08041e.gif)
* related issue(#1358)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
