### PR TITLE
fix: dropdown layer removed before finishing editing (fix #1576)

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/editor.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/editor.spec.ts
@@ -388,10 +388,10 @@ describe('select, checkbox, radio editor', () => {
         cy.gridInstance().invoke('startEditing', 1, 'name');
 
         if (type === 'select') {
-          cy.get('.tui-select-box-dropdown').eq(0).click();
+          cy.get('.tui-select-box-item').eq(0).click();
           cy.getCellByIdx(0, 0).click();
 
-          cy.getCellByIdx(0, 0).should('have.text', 'A');
+          cy.getCellByIdx(1, 0).should('have.text', 'A');
         } else {
           cy.getByCls(`editor-label-icon-${type}`).eq(0).click();
           cy.getCellByIdx(0, 0).click();

--- a/packages/toast-ui.grid/cypress/integration/editor.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/editor.spec.ts
@@ -362,6 +362,7 @@ describe('select, checkbox, radio editor', () => {
           },
         },
       },
+      { name: 'isHuman', defaultValue: true },
     ];
 
     cy.createGrid({ data: dataForGridWithType, columns });
@@ -399,6 +400,28 @@ describe('select, checkbox, radio editor', () => {
             cy.getCellByIdx(1, 0).should('have.text', 'A');
           } else {
             cy.getCellByIdx(1, 0).should('have.text', 'A,B');
+          }
+        }
+      });
+
+      it(`should apply selected value properly when changing focus from left to right(${type})`, () => {
+        createGridWithType(type);
+        cy.gridInstance().invoke('setFrozenColumnCount', 1);
+        cy.gridInstance().invoke('startEditing', 1, 'name');
+
+        if (type === 'select') {
+          cy.get('.tui-select-box-item').eq(0).click();
+          cy.getCell(0, 'isHuman').click();
+
+          cy.getCell(1, 'name').should('have.text', 'A');
+        } else {
+          cy.getByCls(`editor-label-icon-${type}`).eq(0).click();
+          cy.getCell(0, 'isHuman').click();
+
+          if (type === 'radio') {
+            cy.getCell(1, 'name').should('have.text', 'A');
+          } else {
+            cy.getCell(1, 'name').should('have.text', 'A,B');
           }
         }
       });

--- a/packages/toast-ui.grid/src/view/editingLayer.tsx
+++ b/packages/toast-ui.grid/src/view/editingLayer.tsx
@@ -188,17 +188,17 @@ export class EditingLayerComp extends Component<Props> {
     } = this.props;
     const { focusedColumnName, focusedRowKey, active, forcedDestroyEditing } = nextProps;
 
-    if (prevActive && !active) {
-      // eslint-disable-next-line no-unused-expressions
-      this.editor?.beforeDestroy?.();
-    }
-
     if (
       (prevActive && !active && forcedDestroyEditing) ||
       (prevActive &&
         (focusedColumnName !== prevFocusedColumnName || focusedRowKey !== prevFocusedRowKey))
     ) {
       this.saveAndFinishEditing();
+    }
+
+    if (prevActive && !active) {
+      // eslint-disable-next-line no-unused-expressions
+      this.editor?.beforeDestroy?.();
     }
   }
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

- Related issue: #1576 
- Fixed an error that caused the editor to be destroyed before editing was completed.
  - Simply, the problem is due to trying to get values from the editor after destroying it.
  - So, fixed the editor to be destroyed later.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
