### PR TITLE
fix: dynamic row span with scroll

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/rowSpan.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/rowSpan.spec.ts
@@ -4,6 +4,10 @@ import { OptColumn, OptGrid, OptRow } from '@t/options';
 import { invokeFilter, dragAndDropRow } from '../helper/util';
 import { deepCopyArray } from '@/helper/common';
 
+function scrollTo(position: Cypress.PositionType) {
+  cy.getByCls('rside-area', 'body-area').wait(100).scrollTo(position);
+}
+
 function createDataWithRowSpanAttr(): OptRow[] {
   const optRows: OptRow[] = sample.slice();
   optRows[0]._attributes = {
@@ -373,6 +377,17 @@ describe('Dynamic RowSpan', () => {
     cy.getColumnCells('value').each(($el) => {
       cy.wrap($el).should('not.have.attr', 'rowSpan');
     });
+  });
+
+  it.only('should render rowSpan cell properly when scroll', () => {
+    createGridWithRowSpan({
+      data: dataForDynamicRowSpan.concat(dataForDynamicRowSpan),
+      bodyHeight: 200,
+    });
+
+    scrollTo('bottomLeft');
+
+    cy.getCell(9, 'age').should('have.attr', 'rowSpan', '2');
   });
 
   describe('With filter', () => {

--- a/packages/toast-ui.grid/cypress/integration/rowSpan.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/rowSpan.spec.ts
@@ -379,7 +379,7 @@ describe('Dynamic RowSpan', () => {
     });
   });
 
-  it.only('should render rowSpan cell properly when scroll', () => {
+  it('should render rowSpan cell properly when scroll', () => {
     createGridWithRowSpan({
       data: dataForDynamicRowSpan.concat(dataForDynamicRowSpan),
       bodyHeight: 200,

--- a/packages/toast-ui.grid/src/store/data.ts
+++ b/packages/toast-ui.grid/src/store/data.ts
@@ -403,7 +403,8 @@ export function createRawRow(
   row._attributes = getAttributes(row, index, lazyObservable, disabled);
   row._attributes.rowSpan = rowSpan;
   row._disabledPriority = row._disabledPriority || {};
-  (row as Row).rowSpanMap = createRowSpanMap(row, rowSpan, prevRow);
+
+  (row as Row).rowSpanMap = (row as Row).rowSpanMap ?? createRowSpanMap(row, rowSpan, prevRow);
 
   setRowRelationListItems(row as Row, column.columnMapWithRelation);
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed row spans breaking when scrolling.
  * It is caused by observable data and row span attribute that will be depreacted.
    * For performance, the grid set lazy observable to array values like data.
    * Because of this, in initial, only data in viewport change to observable.
    * When scrolling, the data incoming to viewport changes to observable.
      * At this moment, rowSpanMap is set by rowSpan attribute(regardless It is already set).
      * But, dynamic row span implements without row span attribute. It only uses real data.
      * So, I fixed it to use rowSpanMap that was already set.
---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
