### PR TITLE
feat: instant applying of built-in editor

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/datePicker.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/datePicker.spec.ts
@@ -51,6 +51,10 @@ const columns = [
       },
     },
   },
+  {
+    name: 'instantApply',
+    editor: { type: 'datePicker', options: { instantApply: true } },
+  },
 ];
 const data = [
   {
@@ -60,6 +64,7 @@ const data = [
     timePickerWithTab: '2019-11-11 11:11 AM',
     monthPicker: '2019-11',
     yearPicker: '2019',
+    instantApply: '2019-11-11',
   },
 ];
 
@@ -165,4 +170,11 @@ it('focus the editing cell when datepicker layer is closed', () => {
   cy.get('.tui-calendar-date').contains('14').click();
 
   cy.get('@editingInput').should('be.focused');
+});
+
+it('should apply selected value instantly when instantApply option is true', () => {
+  cy.gridInstance().invoke('startEditing', 0, 'instantApply');
+  cy.get('.tui-calendar-date').contains('14').click();
+
+  cy.getCell(0, 'instantApply').should('have.text', '2019-11-14');
 });

--- a/packages/toast-ui.grid/cypress/integration/editor.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/editor.spec.ts
@@ -530,6 +530,77 @@ describe('select, checkbox, radio editor', () => {
       });
     });
   });
+
+  describe('Inatant apply', () => {
+    function createGridWithTypeAndInstantApply(type: string) {
+      const columns = [
+        {
+          name: 'name',
+          formatter: 'listItemText',
+          editor: {
+            type,
+            options: {
+              listItems: [
+                { text: 'A', value: '1' },
+                { text: 'B', value: '2' },
+                { text: 'C', value: '3' },
+              ],
+              instantApply: true,
+            },
+          },
+        },
+        {
+          name: 'isHuman',
+          defaultValue: '2',
+          formatter: 'listItemText',
+          editor: {
+            type,
+            options: {
+              listItems: [
+                { text: 'true', value: '1' },
+                { text: 'false', value: '2' },
+              ],
+              instantApply: true,
+            },
+          },
+        },
+      ];
+
+      cy.createGrid({ data: dataForGridWithType, columns });
+    }
+
+    it('should apply selected value instantly when instantApply option is true(select)', () => {
+      createGridWithTypeAndInstantApply('select');
+      cy.gridInstance().invoke('setFrozenColumnCount', 1);
+      cy.gridInstance().invoke('startEditing', 1, 'isHuman');
+
+      cy.get('.tui-select-box-item').eq(0).click();
+
+      cy.getByCls('editor-select-box-layer').should('be.not.visible');
+      cy.getCell(1, 'isHuman').should('have.text', 'true');
+    });
+
+    it('should apply selected value instantly when instantApply option is true(radio)', () => {
+      createGridWithTypeAndInstantApply('radio');
+      cy.gridInstance().invoke('setFrozenColumnCount', 1);
+      cy.gridInstance().invoke('startEditing', 1, 'isHuman');
+
+      cy.getByCls(`editor-label-icon-radio`).eq(0).click();
+
+      cy.getByCls('editor-checkbox-list-layer').should('be.not.visible');
+      cy.getCell(1, 'isHuman').should('have.text', 'true');
+    });
+
+    it('should not apply selected value instantly when instantApply option is true(checkbox)', () => {
+      createGridWithTypeAndInstantApply('checkbox');
+      cy.gridInstance().invoke('setFrozenColumnCount', 1);
+      cy.gridInstance().invoke('startEditing', 1, 'isHuman');
+
+      cy.getByCls(`editor-label-icon-checkbox`).eq(0).click();
+
+      cy.getByCls('editor-checkbox-list-layer').should('be.visible');
+    });
+  });
 });
 
 // @TODO: should rewrite test case after modifying casting editing value

--- a/packages/toast-ui.grid/cypress/integration/editor.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/editor.spec.ts
@@ -532,7 +532,7 @@ describe('select, checkbox, radio editor', () => {
   });
 
   describe('Inatant apply', () => {
-    function createGridWithTypeAndInstantApply(type: string) {
+    function createGridWithTypeAndInstantApply(type: 'select' | 'radio' | 'checkbox') {
       const columns = [
         {
           name: 'name',

--- a/packages/toast-ui.grid/src/editor/checkbox.ts
+++ b/packages/toast-ui.grid/src/editor/checkbox.ts
@@ -2,6 +2,7 @@ import {
   CellEditor,
   CellEditorProps,
   GridRectForDropDownLayerPos,
+  InstantlyAppliable,
   LayerPos,
   PortalEditingKeydown,
 } from '@t/editor';
@@ -20,7 +21,7 @@ const CHECKED_RADIO_LABEL_CLASSNAME = cls('editor-label-icon-radio-checked');
 const UNCHECKED_CHECKBOX_LABEL_CLASSNAME = cls('editor-label-icon-checkbox');
 const CHECKED_CHECKBOX_LABEL_CLASSNAME = cls('editor-label-icon-checkbox-checked');
 
-export class CheckboxEditor implements CellEditor {
+export class CheckboxEditor implements CellEditor, InstantlyAppliable {
   public el: HTMLElement;
 
   public isMounted = false;
@@ -37,7 +38,7 @@ export class CheckboxEditor implements CellEditor {
 
   private initLayerPos: LayerPos | null = null;
 
-  private instantApplyCallback?: Function;
+  instantApplyCallback: ((...args: any[]) => void) | null = null;
 
   public constructor(props: CellEditorProps) {
     const { columnInfo, width, formattedValue, portalEditingKeydown, instantApplyCallback } = props;

--- a/packages/toast-ui.grid/src/editor/checkbox.ts
+++ b/packages/toast-ui.grid/src/editor/checkbox.ts
@@ -37,14 +37,17 @@ export class CheckboxEditor implements CellEditor {
 
   private initLayerPos: LayerPos | null = null;
 
+  private instantApplyCallback?: Function;
+
   public constructor(props: CellEditorProps) {
-    const { columnInfo, width, formattedValue, portalEditingKeydown } = props;
+    const { columnInfo, width, formattedValue, portalEditingKeydown, instantApplyCallback } = props;
+    const { type: inputType, instantApply } = columnInfo.editor?.options ?? {};
     const el = document.createElement('div');
     const value = String(isNil(props.value) ? '' : props.value);
     el.className = cls('layer-editing-inner');
     el.innerText = formattedValue;
 
-    this.inputType = columnInfo.editor!.options!.type;
+    this.inputType = inputType;
 
     const listItems = getListItems(props);
     const layer = this.createLayer(listItems, width);
@@ -54,6 +57,10 @@ export class CheckboxEditor implements CellEditor {
     this.layer = layer;
 
     this.setValue(value);
+
+    if (instantApply && inputType === 'radio') {
+      this.instantApplyCallback = instantApplyCallback;
+    }
   }
 
   private createLayer(listItems: ListItem[], width: number) {
@@ -119,6 +126,9 @@ export class CheckboxEditor implements CellEditor {
   private onChange = (ev: Event) => {
     const value = (ev.target as HTMLInputElement).value;
     this.setLabelClass(value);
+
+    // eslint-disable-next-line no-unused-expressions
+    this.instantApplyCallback?.();
   };
 
   private onKeydown = (ev: KeyboardEvent) => {

--- a/packages/toast-ui.grid/src/editor/datePicker.ts
+++ b/packages/toast-ui.grid/src/editor/datePicker.ts
@@ -1,11 +1,17 @@
 import TuiDatePicker from 'tui-date-picker';
 import { Dictionary } from '@t/options';
-import { CellEditor, CellEditorProps, GridRectForDropDownLayerPos, LayerPos } from '@t/editor';
+import {
+  CellEditor,
+  CellEditorProps,
+  GridRectForDropDownLayerPos,
+  InstantlyAppliable,
+  LayerPos,
+} from '@t/editor';
 import { cls } from '../helper/dom';
 import { deepMergedCopy, isNumber, isString, isNil, pixelToNumber } from '../helper/common';
 import { setLayerPosition, getContainerElement, setOpacity, moveLayer } from './dom';
 
-export class DatePickerEditor implements CellEditor {
+export class DatePickerEditor implements CellEditor, InstantlyAppliable {
   public el: HTMLDivElement;
 
   public isMounted = false;
@@ -19,6 +25,8 @@ export class DatePickerEditor implements CellEditor {
   private iconEl?: HTMLElement;
 
   private initLayerPos: LayerPos | null = null;
+
+  instantApplyCallback: ((...args: any[]) => void) | null = null;
 
   private createInputElement() {
     const inputEl = document.createElement('input');
@@ -89,6 +97,10 @@ export class DatePickerEditor implements CellEditor {
       options.format = 'yyyy-MM-dd';
     }
 
+    if (options.instantApply) {
+      this.instantApplyCallback = instantApplyCallback;
+    }
+
     if (isNumber(value) || isString(value)) {
       date = new Date(value);
     }
@@ -106,9 +118,9 @@ export class DatePickerEditor implements CellEditor {
     this.datePickerEl = new TuiDatePicker(layer, deepMergedCopy(defaultOptions, options));
     this.datePickerEl.on('close', () => {
       this.focus();
-      if (options.instantApply) {
-        instantApplyCallback();
-      }
+
+      // eslint-disable-next-line no-unused-expressions
+      this.instantApplyCallback?.();
     });
   }
 

--- a/packages/toast-ui.grid/src/editor/datePicker.ts
+++ b/packages/toast-ui.grid/src/editor/datePicker.ts
@@ -57,6 +57,7 @@ export class DatePickerEditor implements CellEditor {
     const {
       grid: { usageStatistics },
       columnInfo,
+      instantApplyCallback,
     } = props;
     const value = String(isNil(props.value) ? '' : props.value);
     const el = document.createElement('div');
@@ -103,7 +104,12 @@ export class DatePickerEditor implements CellEditor {
     };
 
     this.datePickerEl = new TuiDatePicker(layer, deepMergedCopy(defaultOptions, options));
-    this.datePickerEl.on('close', () => this.focus());
+    this.datePickerEl.on('close', () => {
+      this.focus();
+      if (options.instantApply) {
+        instantApplyCallback();
+      }
+    });
   }
 
   public moveDropdownLayer(gridRect: GridRectForDropDownLayerPos) {

--- a/packages/toast-ui.grid/src/editor/select.ts
+++ b/packages/toast-ui.grid/src/editor/select.ts
@@ -4,6 +4,7 @@ import {
   CellEditor,
   CellEditorProps,
   GridRectForDropDownLayerPos,
+  InstantlyAppliable,
   LayerPos,
   PortalEditingKeydown,
 } from '@t/editor';
@@ -14,7 +15,7 @@ import { setLayerPosition, getContainerElement, setOpacity, moveLayer } from './
 import { getKeyStrokeString } from '../helper/keyboard';
 import { includes, isNil, pixelToNumber } from '../helper/common';
 
-export class SelectEditor implements CellEditor {
+export class SelectEditor implements CellEditor, InstantlyAppliable {
   public el: HTMLDivElement;
 
   public isMounted = false;
@@ -28,6 +29,8 @@ export class SelectEditor implements CellEditor {
   private portalEditingKeydown: PortalEditingKeydown;
 
   private initLayerPos: LayerPos | null = null;
+
+  instantApplyCallback: ((...args: any[]) => void) | null = null;
 
   public constructor(props: CellEditorProps) {
     const { width, formattedValue, portalEditingKeydown, columnInfo, instantApplyCallback } = props;
@@ -47,7 +50,8 @@ export class SelectEditor implements CellEditor {
     this.layer.addEventListener('keydown', this.onKeydown);
 
     if (instantApply) {
-      this.selectBoxEl.on('close', instantApplyCallback);
+      this.instantApplyCallback = instantApplyCallback;
+      this.selectBoxEl.on('close', this.instantApplyCallback);
     }
   }
 

--- a/packages/toast-ui.grid/src/editor/select.ts
+++ b/packages/toast-ui.grid/src/editor/select.ts
@@ -30,7 +30,9 @@ export class SelectEditor implements CellEditor {
   private initLayerPos: LayerPos | null = null;
 
   public constructor(props: CellEditorProps) {
-    const { width, formattedValue, portalEditingKeydown } = props;
+    const { width, formattedValue, portalEditingKeydown, columnInfo, instantApplyCallback } = props;
+
+    const { instantApply } = columnInfo.editor?.options ?? {};
     const el = document.createElement('div');
     const value = String(isNil(props.value) ? '' : props.value);
     el.className = cls('layer-editing-inner');
@@ -43,6 +45,10 @@ export class SelectEditor implements CellEditor {
     this.el = el;
     this.layer = layer;
     this.layer.addEventListener('keydown', this.onKeydown);
+
+    if (instantApply) {
+      this.selectBoxEl.on('close', instantApplyCallback);
+    }
   }
 
   private onKeydown = (ev: KeyboardEvent) => {

--- a/packages/toast-ui.grid/src/view/editingLayer.tsx
+++ b/packages/toast-ui.grid/src/view/editingLayer.tsx
@@ -94,7 +94,7 @@ export class EditingLayerComp extends Component<Props> {
     });
   }
 
-  private saveAndFinishEditing(triggeredByKey = false) {
+  private saveAndFinishEditing = (triggeredByKey = false) => {
     const { dispatch, active } = this.props;
 
     if (this.editor && active) {
@@ -103,7 +103,7 @@ export class EditingLayerComp extends Component<Props> {
       dispatch('setValue', rowKey, columnName, value);
       dispatch('finishEditing', rowKey, columnName, value, { save: true, triggeredByKey });
     }
-  }
+  };
 
   private setInitScrollPos() {
     const { bodyScrollTop, bodyScrollLeft } = this.props;
@@ -132,6 +132,7 @@ export class EditingLayerComp extends Component<Props> {
       formattedValue,
       width: right - left,
       portalEditingKeydown: this.handleKeyDown,
+      instantApplyCallback: this.saveAndFinishEditing,
     };
     const cellEditor = new EditorClass(editorProps);
     const editorEl = cellEditor.getElement();

--- a/packages/toast-ui.grid/types/editor/index.d.ts
+++ b/packages/toast-ui.grid/types/editor/index.d.ts
@@ -9,6 +9,8 @@ export type CheckboxOptions = ListItemOptions & {
 
 export type PortalEditingKeydown = (ev: KeyboardEvent) => void;
 
+type InstantApplyCallback = (...args: any[]) => void;
+
 export interface CellEditorProps {
   grid: TuiGrid & { usageStatistics: boolean };
   rowKey: RowKey;
@@ -17,7 +19,7 @@ export interface CellEditorProps {
   formattedValue: string;
   width: number;
   portalEditingKeydown: PortalEditingKeydown;
-  instantApplyCallback: Function;
+  instantApplyCallback: InstantApplyCallback;
 }
 
 export interface CellEditor {
@@ -53,4 +55,8 @@ export interface GridRectForDropDownLayerPos {
 export interface LayerPos {
   top: number;
   left: number;
+}
+
+export interface InstantlyAppliable {
+  instantApplyCallback: InstantApplyCallback | null;
 }

--- a/packages/toast-ui.grid/types/editor/index.d.ts
+++ b/packages/toast-ui.grid/types/editor/index.d.ts
@@ -17,6 +17,7 @@ export interface CellEditorProps {
   formattedValue: string;
   width: number;
   portalEditingKeydown: PortalEditingKeydown;
+  instantApplyCallback: Function;
 }
 
 export interface CellEditor {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Added the feature that is instant applying of built-in editor.
  * It works only for built-in select, checkbox(radio), datePicker editor.
  * For use this, pass the `instantApply` option to `true` in property of options of editor of column.
  * If use it, apply new value by clicking a new value in the dropdown layer of built-in editor.


**Before use it**
![](https://user-images.githubusercontent.com/41339744/158920569-22719155-8a4d-4b0b-bb55-3017bed8a5d8.gif)

**After use it**
![](https://user-images.githubusercontent.com/41339744/158920590-017c0966-4aea-43f0-ad74-204318078dc0.gif)



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
