### PR TITLE
docs: fix wrong CDN URL in getting started documents

### DIFF
--- a/packages/toast-ui.grid/docs/en/getting-started.md
+++ b/packages/toast-ui.grid/docs/en/getting-started.md
@@ -22,9 +22,9 @@ TOAST UI products are available over the CDN powered by [NHN Cloud](https://www.
 You can use the CDN as below.
 
 ``` html
-<link rel="stylesheet" href="https://uicdn.toast.com/tui-grid/latest/tui-grid.css" />
+<link rel="stylesheet" href="https://uicdn.toast.com/grid/latest/tui-grid.css" />
 ...
-<script src="https://uicdn.toast.com/tui-grid/latest/tui-grid.js"></script>
+<script src="https://uicdn.toast.com/grid/latest/tui-grid.js"></script>
 ```
 
 If you want to use a specific version, use the tag name instead of `latest` in the url's path.
@@ -32,13 +32,13 @@ If you want to use a specific version, use the tag name instead of `latest` in t
 The CDN directory has the following structure.
 
 ```
-tui-grid/
+grid/
 ├─ latest/
 │  ├─ tui-grid.css
 │  ├─ tui-grid.min.css
 │  ├─ tui-grid.js
 │  └─ tui-grid.min.js
-├─ v3.8.0/
+├─ v4.21.0/
 │  ├─ ...
 ```
 

--- a/packages/toast-ui.grid/docs/ko/getting-started.md
+++ b/packages/toast-ui.grid/docs/ko/getting-started.md
@@ -19,9 +19,9 @@ $ npm install --save tui-grid # Latest version
 TOAST UI 제품들은 [NHN Cloud](https://www.toast.com/kr)를 통해 CDN을 제공하고 있다. 아래의 코드로 CDN을 이용할 수 있다.
 
 ```html
-<link rel="stylesheet" href="https://uicdn.toast.com/tui-grid/latest/tui-grid.css" />
+<link rel="stylesheet" href="https://uicdn.toast.com/grid/latest/tui-grid.css" />
 ...
-<script src="https://uicdn.toast.com/tui-grid/latest/tui-grid.js"></script>
+<script src="https://uicdn.toast.com/grid/latest/tui-grid.js"></script>
 ```
 
 특정 버전을 사용할 때는 `latest` 대신 버전에 해당하는 태그 네임을 URL에 사용한다.
@@ -29,13 +29,13 @@ TOAST UI 제품들은 [NHN Cloud](https://www.toast.com/kr)를 통해 CDN을 제
 CDN은 아래의 디렉토리 구조로 구성되어 있다.
 
 ```
-tui-grid/
+grid/
 ├─ latest/
 │  ├─ tui-grid.css
 │  ├─ tui-grid.min.css
 │  ├─ tui-grid.js
 │  └─ tui-grid.min.js
-├─ v3.8.0/
+├─ v4.21.0/
 │  ├─ ...
 ```
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed incorrect CDN URL in getting started documentation.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
