### PR TITLE
fix: add appended rows to modified data

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/data.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/data.spec.ts
@@ -894,6 +894,17 @@ describe('appendRows()', () => {
 
     assertHeaderCheckboxStatus(false);
   });
+
+  it('should add appended rows to modified data', () => {
+    createGrid();
+
+    cy.gridInstance().invoke('appendRows', [
+      { name: 'Han', age: 21 },
+      { name: 'Ryu', age: 25 },
+    ]);
+
+    cy.gridInstance().invoke('getModifiedRows').its('createdRows').should('have.length', 2);
+  });
 });
 
 describe('setValue()', () => {

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -891,6 +891,7 @@ export function appendRows(store: Store, inputData: OptRow[]) {
   resetSortKey(data, startIndex);
   sortByCurrentState(store);
   updateHeights(store);
+  rawData.forEach((rawRow) => getDataManager(id).push('CREATE', rawRow));
   postUpdateAfterManipulation(store, startIndex, 'DONE', rawData);
   updateRowSpan(store);
 }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed that, Unlike the `appendRow` API, when new rows are added using the `appendRows` API, the rows are not added to the `createdRows` in the `modifiedData`.
  * Fixed it by pushing each added row to the data manager with "CREATE". 

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
