### PR TITLE
fix: maintain all row spans after editing some cell

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/rowSpan.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/rowSpan.spec.ts
@@ -65,6 +65,19 @@ it('render rowSpan cell properly', () => {
   cy.getCell(4, 'artist').should('have.attr', 'rowSpan', '3');
 });
 
+it('should render rowSpan cell properly after some cell edited', () => {
+  cy.createGrid({ data, columns });
+
+  cy.gridInstance().invoke('startEditing', 0, 'name');
+  cy.getByCls('content-text').type('Kim');
+  cy.gridInstance().invoke('finishEditing', 0, 'name');
+
+  cy.getCell(0, 'name').should('have.attr', 'rowSpan', '2');
+  cy.getCell(0, 'artist').should('have.attr', 'rowSpan', '3');
+  cy.getCell(3, 'name').should('have.attr', 'rowSpan', '3');
+  cy.getCell(4, 'artist').should('have.attr', 'rowSpan', '3');
+});
+
 describe('getRowSpanData()', () => {
   beforeEach(() => {
     cy.createGrid({ data, columns });

--- a/packages/toast-ui.grid/src/dispatch/rowSpan.ts
+++ b/packages/toast-ui.grid/src/dispatch/rowSpan.ts
@@ -138,14 +138,16 @@ function updateSubRowSpan(
   }
 }
 
-export function resetRowSpan({ data }: Store, slient = false) {
-  data.rawData.forEach(({ rowSpanMap }) => {
-    Object.keys(rowSpanMap).forEach((columnName) => {
-      delete rowSpanMap[columnName];
+export function resetRowSpan({ data, column }: Store, slient = false) {
+  if (column.visibleRowSpanEnabledColumns.length > 0) {
+    data.rawData.forEach(({ rowSpanMap }) => {
+      Object.keys(rowSpanMap).forEach((columnName) => {
+        delete rowSpanMap[columnName];
+      });
     });
-  });
 
-  if (!slient) {
-    notify(data, 'rawData', 'filteredRawData', 'viewData', 'filteredViewData');
+    if (!slient) {
+      notify(data, 'rawData', 'filteredRawData', 'viewData', 'filteredViewData');
+    }
   }
 }

--- a/packages/toast-ui.grid/src/dispatch/rowSpan.ts
+++ b/packages/toast-ui.grid/src/dispatch/rowSpan.ts
@@ -139,15 +139,17 @@ function updateSubRowSpan(
 }
 
 export function resetRowSpan({ data, column }: Store, slient = false) {
-  if (column.visibleRowSpanEnabledColumns.length > 0) {
-    data.rawData.forEach(({ rowSpanMap }) => {
-      Object.keys(rowSpanMap).forEach((columnName) => {
-        delete rowSpanMap[columnName];
-      });
-    });
+  if (column.visibleRowSpanEnabledColumns.length <= 0) {
+    return;
+  }
 
-    if (!slient) {
-      notify(data, 'rawData', 'filteredRawData', 'viewData', 'filteredViewData');
-    }
+  data.rawData.forEach(({ rowSpanMap }) => {
+    Object.keys(rowSpanMap).forEach((columnName) => {
+      delete rowSpanMap[columnName];
+    });
+  });
+
+  if (!slient) {
+    notify(data, 'rawData', 'filteredRawData', 'viewData', 'filteredViewData');
   }
 }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x]Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed an issue that the row spans released after editing some cell.
  * It occurs by resetting row spans regardless of using dynamic row span.
  * Changed to reset row spans when only using dynamic row span.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
