### PR TITLE
fix: paste more rows than rows of the grid (fix #1635)

### DIFF
--- a/packages/toast-ui.grid/src/dispatch/keyboard.ts
+++ b/packages/toast-ui.grid/src/dispatch/keyboard.ts
@@ -15,7 +15,7 @@ import { copyDataToRange, getRangeToPaste } from '../query/clipboard';
 import { mapProp } from '../helper/common';
 import { CellChange, Origin } from '@t/event';
 import { updateAllSummaryValues } from './summary';
-import { updateHeights } from './data';
+import { appendRows, updateHeights } from './data';
 
 type ChangeValueFn = () => number;
 interface ChangeInfo {
@@ -230,7 +230,11 @@ function applyCopiedData(store: Store, copiedData: string[][], range: SelectionR
 }
 
 export function paste(store: Store, copiedData: string[][]) {
-  const { selection, id } = store;
+  const {
+    selection,
+    id,
+    data: { viewData },
+  } = store;
   const { originalRange } = selection;
 
   if (originalRange) {
@@ -238,6 +242,15 @@ export function paste(store: Store, copiedData: string[][]) {
   }
 
   const rangeToPaste = getRangeToPaste(store, copiedData);
+  const endRowIndex = rangeToPaste.row[1];
+
+  if (endRowIndex > viewData.length - 1) {
+    appendRows(
+      store,
+      [...Array(endRowIndex - viewData.length + 1)].map(() => ({}))
+    );
+  }
+
   applyCopiedData(store, copiedData, rangeToPaste);
   changeSelectionRange(selection, rangeToPaste, id);
 }

--- a/packages/toast-ui.grid/src/query/clipboard.ts
+++ b/packages/toast-ui.grid/src/query/clipboard.ts
@@ -4,7 +4,7 @@ import { ListItemOptions } from '@t/editor';
 import { Store } from '@t/store';
 import { SelectionRange, Range } from '@t/store/selection';
 import { find, isNull, isNil } from '../helper/common';
-import { makeObservable } from '../dispatch/data';
+import { appendRows, makeObservable } from '../dispatch/data';
 import { isObservable, notify } from '../helper/observable';
 
 function getCustomValue(
@@ -118,9 +118,16 @@ export function getRangeToPaste(store: Store, pasteData: string[][]): SelectionR
     startColumnIndex = totalColumnIndex!;
   }
 
-  const endRowIndex = Math.min(pasteData.length + startRowIndex, viewData.length) - 1;
+  const endRowIndex = pasteData.length + startRowIndex - 1;
   const endColumnIndex =
     Math.min(pasteData[0].length + startColumnIndex, visibleColumnsWithRowHeader.length) - 1;
+
+  if (endRowIndex > viewData.length - 1) {
+    appendRows(
+      store,
+      [...Array(endRowIndex - viewData.length + 1)].map(() => ({}))
+    );
+  }
 
   return {
     row: [startRowIndex, endRowIndex],

--- a/packages/toast-ui.grid/src/query/clipboard.ts
+++ b/packages/toast-ui.grid/src/query/clipboard.ts
@@ -4,7 +4,7 @@ import { ListItemOptions } from '@t/editor';
 import { Store } from '@t/store';
 import { SelectionRange, Range } from '@t/store/selection';
 import { find, isNull, isNil } from '../helper/common';
-import { appendRows, makeObservable } from '../dispatch/data';
+import { makeObservable } from '../dispatch/data';
 import { isObservable, notify } from '../helper/observable';
 
 function getCustomValue(
@@ -106,7 +106,6 @@ export function getRangeToPaste(store: Store, pasteData: string[][]): SelectionR
     selection: { originalRange },
     focus: { totalColumnIndex, originalRowIndex },
     column: { visibleColumnsWithRowHeader },
-    data: { viewData },
   } = store;
   let startRowIndex, startColumnIndex;
 
@@ -121,13 +120,6 @@ export function getRangeToPaste(store: Store, pasteData: string[][]): SelectionR
   const endRowIndex = pasteData.length + startRowIndex - 1;
   const endColumnIndex =
     Math.min(pasteData[0].length + startColumnIndex, visibleColumnsWithRowHeader.length) - 1;
-
-  if (endRowIndex > viewData.length - 1) {
-    appendRows(
-      store,
-      [...Array(endRowIndex - viewData.length + 1)].map(() => ({}))
-    );
-  }
 
   return {
     row: [startRowIndex, endRowIndex],


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed an issue where data was truncated when pasting more rows than the number of rows in the grid.
  * When calculating the range to be pasted during paste, if it exceeds the row range of the current grid, it adds as many blank rows as it exceeds and then performs pasting.
* The test could not be added due to a [Clipboard issue in Cypress](https://github.com/cypress-io/cypress/issues/2386).

**As-Is**

![](https://user-images.githubusercontent.com/41339744/170424671-db5627b3-14a0-450a-a4d6-8ff6503d1c3b.gif)

**To-Be**

![](https://user-images.githubusercontent.com/41339744/170424813-bb7dffd0-fbae-4450-b958-442fb4614977.gif)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
