### PR TITLE
fix: check buttons are not applied in view after sort (fix #1667)

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/rowHeaders.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/rowHeaders.spec.ts
@@ -4,7 +4,7 @@ import {
   assertHeaderCheckboxStatus,
 } from '../helper/assert';
 
-const columns = [{ name: 'name', minWidth: 150 }];
+const columns = [{ name: 'name', minWidth: 150, sortable: true }];
 
 before(() => {
   cy.visit('/dist');
@@ -38,6 +38,26 @@ describe('row header API', () => {
   });
 
   it('checkAll, uncheckAll', () => {
+    cy.gridInstance().invoke('checkAll');
+
+    cy.get('input').should(($el) => {
+      $el.each((_, elem) => {
+        expect(elem.checked).to.be.true;
+      });
+    });
+
+    cy.gridInstance().invoke('uncheckAll');
+
+    cy.get('input').should(($el) => {
+      $el.each((_, elem) => {
+        expect(elem.checked).to.be.false;
+      });
+    });
+  });
+
+  it('checkAll, uncheckAll after sort', () => {
+    cy.gridInstance().invoke('sort', 'name', true);
+
     cy.gridInstance().invoke('checkAll');
 
     cy.get('input').should(($el) => {

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -419,6 +419,8 @@ export function checkAll(store: Store, allPage?: boolean) {
   const { id } = store;
   setAllRowAttribute(store, 'checked', true, allPage);
   setCheckedAllRows(store);
+  notify(store.data, 'rawData', 'filteredRawData', 'viewData', 'filteredViewData');
+
   const eventBus = getEventBus(id);
   const gridEvent = new GridEvent();
 
@@ -434,6 +436,8 @@ export function uncheckAll(store: Store, allPage?: boolean) {
   const { id } = store;
   setAllRowAttribute(store, 'checked', false, allPage);
   setCheckedAllRows(store);
+  notify(store.data, 'rawData', 'filteredRawData', 'viewData', 'filteredViewData');
+
   const eventBus = getEventBus(id);
   const gridEvent = new GridEvent();
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

related issue: #1667 

* Fixed the problem that rows in the view were not reflected when clicking the checkbox in the header area after sorting.
  * This happened because in an observable data system, the data was transformed by sorting and not notified of changes normally.

**As-Is**
![](https://user-images.githubusercontent.com/41339744/174051196-a986d802-5fa0-49c8-a198-efb24fdf6fa2.gif)


**To-Be**
![](https://user-images.githubusercontent.com/41339744/174051280-8a06eb32-61cc-4b77-b3a1-062043385a6a.gif)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
