### PR TITLE
fix: context menu shows inside container

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/contextMenu.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/contextMenu.spec.ts
@@ -3,25 +3,13 @@ import { CreateMenuGroups } from '@t/store/contextMenu';
 import i18n from '@/i18n';
 import { cls } from '@/helper/dom';
 
+const GRID_WIDTH = 800;
+const GRID_BODY_HEIGHT = 180;
+const GRID_HEADER_HEIGHT = 40;
+
 before(() => {
   cy.visit('/dist');
 });
-
-function createGridWithLargeData() {
-  const data = [];
-  const columns = [
-    { name: 'name' },
-    { name: 'age' },
-    { name: 'city', defaultValue: 'seoul' },
-    { name: 'job', defaultValue: 'unemployed' },
-  ];
-
-  for (let i = 0; i < 100; i += 1) {
-    data.push({ name: `Lee${i}`, age: i });
-  }
-
-  cy.createGrid({ data, columns });
-}
 
 function createGridWithContextMenu(contextMenu?: CreateMenuGroups) {
   i18n.setLanguage('en');
@@ -33,7 +21,13 @@ function createGridWithContextMenu(contextMenu?: CreateMenuGroups) {
   ];
   const columns = [{ name: 'name' }, { name: 'age' }];
 
-  cy.createGrid({ data, columns, contextMenu });
+  cy.createGrid({
+    data,
+    columns,
+    contextMenu,
+    bodyHeight: GRID_BODY_HEIGHT,
+    header: { height: GRID_HEADER_HEIGHT },
+  });
 }
 
 function assertMenuItemByText(text: string) {
@@ -46,13 +40,6 @@ function showContextMenu(rowKey: RowKey, columnName: string) {
 
 function getMenuItemByText(text: string) {
   return cy.contains(`.${cls('context-menu')} .menu-item`, text);
-}
-
-function isInViewport(element: HTMLElement) {
-  const { top, left, right, bottom } = element.getBoundingClientRect();
-  const { viewportHeight, viewportWidth } = Cypress.config();
-
-  return top >= 0 && left >= 0 && bottom <= viewportHeight && right <= viewportWidth;
 }
 
 describe('context menu', () => {
@@ -247,20 +234,24 @@ describe('context menu', () => {
     cy.getByCls('context-menu').should('be.not.visible');
   });
 
-  it('should always display inside viewport', () => {
-    createGridWithLargeData();
-
-    showContextMenu(0, 'job');
+  it('should always display inside grid container', () => {
+    createGridWithContextMenu();
+    showContextMenu(0, 'age');
 
     cy.get(`.${cls('context-menu')}`).should(($el) => {
-      expect(isInViewport($el[0])).to.be.true;
+      const { offsetTop, offsetLeft, clientWidth, clientHeight } = $el[0];
+
+      expect(offsetTop).to.be.greaterThan(0);
+      expect(offsetLeft).to.be.greaterThan(0);
+      expect(offsetLeft + clientWidth).to.be.lessThan(GRID_WIDTH);
+      expect(offsetTop + clientHeight).to.be.lessThan(GRID_BODY_HEIGHT + GRID_HEADER_HEIGHT);
     });
   });
 
-  it('should change displaying direction of submenus when there is no space to diplay sub context menu', () => {
-    createGridWithLargeData();
+  it('should change displaying direction of submenus when there is no space to display sub context menu', () => {
+    createGridWithContextMenu();
 
-    showContextMenu(0, 'job');
+    showContextMenu(0, 'age');
     getMenuItemByText('Export').trigger('mouseenter');
 
     cy.get(`.${cls('context-menu')} .${cls('context-menu')}`).should(($el) => {

--- a/packages/toast-ui.grid/src/view/container.tsx
+++ b/packages/toast-ui.grid/src/view/container.tsx
@@ -352,7 +352,7 @@ export class ContainerComp extends Component<Props> {
     ev.preventDefault();
 
     const { offsetLeft, offsetTop } = this.props;
-    const { innerWidth, innerHeight } = window;
+    const { clientHeight, clientWidth } = this.el!;
     const [pageX, pageY] = getCoordinateWithOffset(ev.pageX, ev.pageY);
     const bodyArea = findParentByClassName(ev.target as HTMLElement, 'body-area')!;
     const side: Side = findParentByClassName(bodyArea, 'lside-area') ? 'L' : 'R';
@@ -362,8 +362,8 @@ export class ContainerComp extends Component<Props> {
     const pos = {
       top: ev.clientY - offsetTop,
       left: ev.clientX - offsetLeft,
-      bottom: innerHeight - pageY,
-      right: innerWidth - pageX,
+      bottom: clientHeight + offsetTop - pageY,
+      right: clientWidth + offsetLeft - pageX,
     };
 
     const elementInfo = { scrollTop, scrollLeft, side, top, left };

--- a/packages/toast-ui.grid/src/view/contextMenuItem.tsx
+++ b/packages/toast-ui.grid/src/view/contextMenuItem.tsx
@@ -7,11 +7,18 @@ import { ContextMenu } from './contextMenu';
 import { cls } from '../helper/dom';
 import { DEFAULT_SUB_CONTEXT_MENU_TOP } from '../helper/constant';
 
+interface StoreProps {
+  gridWidth: number;
+  gridHeight: number;
+  gridOffsetLeft: number;
+  gridOffsetTop: number;
+}
+
 interface OwnProps {
   menuItem: MenuItem;
 }
 
-type Props = OwnProps & DispatchProps;
+type Props = StoreProps & OwnProps & DispatchProps;
 
 interface State {
   subMenuInfo: {
@@ -24,25 +31,26 @@ class ContextMenuItemComp extends Component<Props, State> {
   private container: HTMLElement | null = null;
 
   private showSubMenu = (ev: MouseEvent) => {
-    const { menuItem } = this.props;
+    const { menuItem, gridHeight, gridWidth, gridOffsetLeft, gridOffsetTop } = this.props;
 
     if (menuItem.subMenu?.length) {
       const { offsetWidth, offsetTop, parentElement } = ev.target as HTMLElement;
-      const { innerWidth, innerHeight, scrollX, scrollY } = window;
+      const { scrollX, scrollY } = window;
 
-      let bottom = innerHeight + scrollY - (offsetTop + DEFAULT_SUB_CONTEXT_MENU_TOP);
-      let right = innerWidth + scrollX - offsetWidth;
+      let bottom =
+        gridHeight + gridOffsetTop + scrollY - (offsetTop + DEFAULT_SUB_CONTEXT_MENU_TOP);
+      let right = gridWidth + gridOffsetLeft + scrollX - offsetWidth;
 
       let element = ev.target as HTMLElement;
 
-      do {
+      while (!element.className.match(cls('container'))) {
         element = element.parentElement!;
 
         const { offsetTop: parentOffsetTop, offsetLeft: parentOffsetLeft } = element;
 
         right -= parentOffsetLeft;
         bottom -= parentOffsetTop;
-      } while (!element.className.match(cls('container')));
+      }
 
       const needReverse = this.container!.offsetWidth > right || parentElement!.offsetLeft < 0;
 
@@ -120,4 +128,9 @@ class ContextMenuItemComp extends Component<Props, State> {
   }
 }
 
-export const ContextMenuItem = connect<{}, OwnProps>()(ContextMenuItemComp);
+export const ContextMenuItem = connect<StoreProps, OwnProps>(({ dimension }) => ({
+  gridWidth: dimension.width,
+  gridHeight: dimension.bodyHeight + dimension.headerHeight,
+  gridOffsetLeft: dimension.offsetLeft,
+  gridOffsetTop: dimension.offsetTop,
+}))(ContextMenuItemComp);


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed the context menu to show inside the container.
* Instead of using the window's height and width, changed it to use the information from the container.

**As-Is**
![](https://user-images.githubusercontent.com/41339744/176078305-490aeff4-5e9d-402f-b93e-b3c9b702e634.gif)


**To-Be**
![](https://user-images.githubusercontent.com/41339744/176078277-ade64a4f-a3c7-4a20-8eac-1631fc99e2f7.gif)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
