### PR TITLE
fix: change filtered summary properly when no filter is set

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/summary.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/summary.spec.ts
@@ -473,6 +473,15 @@ describe('summary with filter', () => {
     cy.gridInstance().invoke('filter', 'downloadCount', [{ code: 'eq', value: 2 }]);
   });
 
+  it('should change summary when changes value if no filter is set', () => {
+    cy.gridInstance().invoke('unfilter', 'downloadCount');
+    cy.gridInstance().invoke('setValue', 0, 'downloadCount', 2);
+
+    cy.gridInstance()
+      .invoke('getSummaryValues', 'downloadCount')
+      .should('have.deep.property', 'filtered', { sum: 6, min: 2, max: 2, avg: 2, cnt: 3 });
+  });
+
   it('should change summary based on the filtering result.', () => {
     assertSummaryContent(
       'downloadCount',

--- a/packages/toast-ui.grid/src/dispatch/summary.ts
+++ b/packages/toast-ui.grid/src/dispatch/summary.ts
@@ -94,10 +94,17 @@ function updateSummaryValue(
   const avg = sum / cnt;
   const filteredAvg = filteredSum / filteredCnt;
 
-  min = Math.min(value, min);
-  max = Math.max(value, max);
-  filteredMin = Math.min(value, filteredMin);
-  filteredMax = Math.max(value, filteredMax);
+  const columnData = data.rawData.map((row: Row) => Number(row[columnName]));
+
+  min = Math.min(value, ...columnData);
+  max = Math.max(value, ...columnData);
+
+  if (hasColumnFilter) {
+    const filteredColumnData = data.filteredRawData.map((row) => Number(row[columnName]));
+
+    filteredMin = Math.min(value, ...filteredColumnData);
+    filteredMax = Math.max(value, ...filteredColumnData);
+  }
 
   summary.summaryValues[columnName] = {
     sum,

--- a/packages/toast-ui.grid/src/dispatch/summary.ts
+++ b/packages/toast-ui.grid/src/dispatch/summary.ts
@@ -105,13 +105,15 @@ function updateSummaryValue(
     max,
     avg,
     cnt,
-    filtered: {
-      sum: filteredSum,
-      min: filteredMin,
-      max: filteredMax,
-      avg: filteredAvg,
-      cnt: filteredCnt,
-    },
+    filtered: hasColumnFilter
+      ? {
+          sum: filteredSum,
+          min: filteredMin,
+          max: filteredMax,
+          avg: filteredAvg,
+          cnt: filteredCnt,
+        }
+      : { sum, min, max, avg, cnt },
   };
 
   notify(summary, 'summaryValues');


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed an issue where the value of `filtered` in the `summary` value is not set properly when no filter is set.
  * It was caused by not updating the value unless the filter was set.
  * Fixed to return the same value as the default `summary` value if no filter is set.
* In addition, the problem that `min` and `max` was not updated correctly when the data of cells that had values corresponding to `min` and `max` was changed has been fixed.
---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
