### PR TITLE
fix: fit to parent height without padding (fix #1756)

### DIFF
--- a/packages/toast-ui.grid/src/dispatch/dimension.ts
+++ b/packages/toast-ui.grid/src/dispatch/dimension.ts
@@ -39,7 +39,9 @@ export function refreshLayout(store: Store, containerEl: HTMLElement, parentEl: 
   setWidth(store, clientWidth, autoWidth);
 
   if (fitToParentHeight && parentEl && parentEl.clientHeight !== clientHeight) {
-    setHeight(store, parentEl.clientHeight);
+    const { paddingTop, paddingBottom } = getComputedStyle(parentEl);
+
+    setHeight(store, parentEl.clientHeight - (parseFloat(paddingTop) + parseFloat(paddingBottom)));
   }
 }
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed an issue where the height including the 'padding' of the parent element was set when the Grid's 'bodyHeight' was set to 'fitToParent'.
  * This was caused by not subtracting the width of `padding` while setting the height using `clientHeight` which returns a value including `padding`.

**As-Is**
<img width="706" alt="스크린샷 2022-08-10 오후 12 42 42" src="https://user-images.githubusercontent.com/41339744/183808233-9246ed0f-15f8-4062-a534-b7355b040200.png">


**To-Be**
<img width="706" alt="스크린샷 2022-08-10 오후 12 42 11" src="https://user-images.githubusercontent.com/41339744/183808179-63586b5f-5af8-4137-ac7e-5977881bfdd7.png">



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
