### PR TITLE
feat: add setRows api for setting multiple rows

### DIFF
--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -846,6 +846,7 @@ export function setRows(store: Store, rows: OptRow[]) {
 
   let currentStartIndex = 0;
 
+  // https://github.com/nhn/tui.grid/pull/1786#issuecomment-1255760066
   createdRowInfos.slice(1).forEach(({ rowIndex }, index) => {
     const isLast = index === createdRowInfos.length - 2;
     const prevRowIndex = createdRowInfos[index].rowIndex;

--- a/packages/toast-ui.grid/src/grid.tsx
+++ b/packages/toast-ui.grid/src/grid.tsx
@@ -1777,6 +1777,7 @@ export default class Grid implements TuiGrid {
 
   /**
    * Set new data to the all rows identified by the specified rowKey.
+   * Use setRows for a lot of data, as using setRow can cause performance issues.
    * @param {object} rows - The object that contains all values in the row with rowKey.
    */
   public setRows(rows: OptRow[]) {
@@ -1785,6 +1786,7 @@ export default class Grid implements TuiGrid {
 
   /**
    * Move the row identified by the specified rowKey to target index.
+   * Use setRows for a lot of data, as using setRow can cause performance issues.
    * If data is sorted or filtered, this couldn't be used.
    * @param {number|string} rowKey - The unique key of the row
    * @param {number} targetIndex - Target index for moving

--- a/packages/toast-ui.grid/src/grid.tsx
+++ b/packages/toast-ui.grid/src/grid.tsx
@@ -1776,6 +1776,14 @@ export default class Grid implements TuiGrid {
   }
 
   /**
+   * Set new data to the all rows identified by the specified rowKey.
+   * @param {object} rows - The object that contains all values in the row with rowKey.
+   */
+  public setRows(rows: OptRow[]) {
+    this.dispatch('setRows', rows);
+  }
+
+  /**
    * Move the row identified by the specified rowKey to target index.
    * If data is sorted or filtered, this couldn't be used.
    * @param {number|string} rowKey - The unique key of the row

--- a/packages/toast-ui.grid/src/query/data.ts
+++ b/packages/toast-ui.grid/src/query/data.ts
@@ -242,6 +242,27 @@ export function getCreatedRowInfo(store: Store, rowIndex: number, row: OptRow, r
   return { rawRow, viewRow, prevRow };
 }
 
+export function getCreatedRowInfos(
+  store: Store,
+  indexedRows: { rowIndex: number; row: OptRow; orgRow: Row }[]
+) {
+  const { data, column, id } = store;
+  const { rawData } = data;
+  const index = getMaxRowKey(data);
+
+  return indexedRows.map(({ rowIndex, row, orgRow }, i) => {
+    generateDataCreationKey();
+
+    const prevRow = rawData[rowIndex - 1];
+    const options = { prevRow, lazyObservable: true };
+
+    const rawRow = createRawRow(id, { ...column.emptyRow, ...row }, index + i, column, options);
+    const viewRow = { rowKey: row.rowKey, sortKey: row.sortKey, uniqueKey: row.uniqueKey };
+
+    return { rowIndex, row: { rawRow, viewRow, prevRow }, orgRow };
+  });
+}
+
 export function isSorted(data: Data) {
   return data.sortState.columns[0].columnName !== 'sortKey';
 }

--- a/packages/toast-ui.grid/types/index.d.ts
+++ b/packages/toast-ui.grid/types/index.d.ts
@@ -285,6 +285,8 @@ declare namespace tui {
 
     public setRow(rowKey: RowKey, row: OptRow): void;
 
+    public setRows(rows: OptRow[]): void;
+
     public moveRow(rowKey: RowKey, targetIndex: number, options: OptMoveRow): void;
 
     public setRequestParams(params: Dictionary<any>): void;


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Added `setRows` API for setting multi rows
  * Previously, the only way to set rows was the `setRow` API, which caused performance issues when setting multiple rows.
  * As a result of self-test, when setting 8000 rows of 4 columns, it took about 100 seconds on average with the existing method, but about 600 ms on average when using the `setRows` API. (Performance improvement of about 150 times)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
