### PR TITLE
fix: validate api occurs an error when there is folded tree row

### DIFF
--- a/packages/toast-ui.grid/src/query/validation.ts
+++ b/packages/toast-ui.grid/src/query/validation.ts
@@ -1,5 +1,7 @@
 import { Store } from '@t/store';
 import { InvalidRow } from '@t/store/data';
+import { makeObservable } from '../dispatch/data';
+import { isObservable } from '../helper/observable';
 import { createObservableData } from '../dispatch/lazyObservable';
 
 export function getInvalidRows(store: Store) {
@@ -8,6 +10,12 @@ export function getInvalidRows(store: Store) {
 
   const { data, column } = store;
   const invalidRows: InvalidRow[] = [];
+
+  data.rawData.forEach((row, rowIndex) => {
+    if (!isObservable(row)) {
+      makeObservable(store, rowIndex, true);
+    }
+  });
 
   data.viewData.forEach(({ rowKey, valueMap }) => {
     const invalidColumns = column.validationColumns.filter(


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed an issue that is occurring an error when calling [`validate`](https://nhn.github.io/tui.grid/latest/Grid#validate) with folded tree row.
  * The tree row that has never been opened is not observable data. So, view data of it doesn't have any value properties.
  * Because it doesn't have any properties needed for validating, The error occurred.
  * So, before validating, check if there is non-observable row and then change it to an observable row.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
