### PR TITLE
feat: autoInsertRow option

### DIFF
--- a/packages/toast-ui.grid/src/grid.tsx
+++ b/packages/toast-ui.grid/src/grid.tsx
@@ -287,6 +287,7 @@ if ((module as any).hot) {
  *      @param {function} [options.onGridBeforeDestroy] - The function that will be called before destroying the grid.
  *      @param {boolean} [options.draggable] - Whether to enable to drag the row for changing the order of rows.
  *      @param {Array} [options.contextMenu] - Option array for the context menu.
+ *      @param {boolean} [options.autoInsertRow=true] - Whether to automatically insert rows when there are not enough rows to paste.
  */
 export default class Grid implements TuiGrid {
   el: HTMLElement;

--- a/packages/toast-ui.grid/src/query/clipboard.ts
+++ b/packages/toast-ui.grid/src/query/clipboard.ts
@@ -106,6 +106,7 @@ export function getRangeToPaste(store: Store, pasteData: string[][]): SelectionR
     selection: { originalRange },
     focus: { totalColumnIndex, originalRowIndex },
     column: { visibleColumnsWithRowHeader },
+    data: { viewData, autoInsertRow },
   } = store;
   let startRowIndex, startColumnIndex;
 
@@ -117,7 +118,9 @@ export function getRangeToPaste(store: Store, pasteData: string[][]): SelectionR
     startColumnIndex = totalColumnIndex!;
   }
 
-  const endRowIndex = pasteData.length + startRowIndex - 1;
+  const endRowIndex = autoInsertRow
+    ? pasteData.length + startRowIndex - 1
+    : Math.min(pasteData.length + startRowIndex, viewData.length) - 1;
   const endColumnIndex =
     Math.min(pasteData[0].length + startColumnIndex, visibleColumnsWithRowHeader.length) - 1;
 

--- a/packages/toast-ui.grid/src/store/create.ts
+++ b/packages/toast-ui.grid/src/store/create.ts
@@ -44,6 +44,7 @@ export function createStore(id: number, options: OptGrid): Store {
     header = {},
     disabled = false,
     draggable = false,
+    autoInsertRow = true,
     contextMenu: createMenuGroups,
   } = options;
   const { frozenBorderWidth } = columnOptions;
@@ -76,6 +77,7 @@ export function createStore(id: number, options: OptGrid): Store {
     useClientSort,
     id,
     disabled,
+    autoInsertRow,
   });
   const dimension = createDimension({
     column,
@@ -140,6 +142,7 @@ export function createStore(id: number, options: OptGrid): Store {
     renderState,
     filterLayerState,
     contextMenu,
+    autoInsertRow,
   });
   // manual observe to resolve circular references
   observe(() => {

--- a/packages/toast-ui.grid/src/store/data.ts
+++ b/packages/toast-ui.grid/src/store/data.ts
@@ -48,6 +48,7 @@ interface DataOption {
   useClientSort: boolean;
   id: number;
   disabled: boolean;
+  autoInsertRow: boolean;
 }
 
 interface DataCreationOption {
@@ -530,6 +531,7 @@ export function create({
   useClientSort,
   disabled,
   id,
+  autoInsertRow,
 }: DataOption) {
   const { rawData, viewData } = createData(id, data, column, { lazyObservable: true, disabled });
 
@@ -549,6 +551,7 @@ export function create({
     viewData,
     sortState,
     pageOptions,
+    autoInsertRow,
     checkedAllRows: rawData.length ? !rawData.some((row) => !row._attributes.checked) : false,
     disabledAllCheckbox: disabled,
     filters: null,

--- a/packages/toast-ui.grid/types/options.d.ts
+++ b/packages/toast-ui.grid/types/options.d.ts
@@ -115,6 +115,7 @@ export interface OptGrid {
   onGridBeforeDestroy?: GridEventListener;
   draggable?: boolean;
   contextMenu?: CreateMenuGroups;
+  autoInsertRow?: boolean;
 }
 
 export type OptRowProp = CellValue | RecursivePartial<RowAttributes & RowSpanAttribute> | OptRow[];

--- a/packages/toast-ui.grid/types/store/data.d.ts
+++ b/packages/toast-ui.grid/types/store/data.d.ts
@@ -1,4 +1,4 @@
-import { Dictionary, RecursivePartial } from '../options';
+import { Dictionary } from '../options';
 import { Filter } from './filterLayerState';
 import { InvalidColumn, Comparator, ErrorInfo } from './column';
 import { Range } from './selection';
@@ -137,6 +137,7 @@ export interface Data {
   filters: Filter[] | null;
   loadingState: LoadingState;
   clickedCheckboxRowkey: RowKey | null;
+  autoInsertRow: boolean;
 }
 
 export type RemoveTargetRows = {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description
* if this option set to false, data exceeding thel number of rows is truncated when pasting.

* autoInsertRow=true (default)
![option true](https://user-images.githubusercontent.com/47706141/197656252-f09fcfda-3ece-44b4-9698-c01bc27efe98.gif)

* autoInsertRow=false
![option false](https://user-images.githubusercontent.com/47706141/197657277-eb097275-78fd-4181-a46c-79544dc4b366.gif)

###  related issues
#1685 #1788
---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨

