### PR TITLE
fix: flickering rows when mouse wheel scroll

### DIFF
--- a/packages/toast-ui.grid/src/view/bodyArea.tsx
+++ b/packages/toast-ui.grid/src/view/bodyArea.tsx
@@ -114,6 +114,14 @@ class BodyAreaComp extends Component<Props> {
     this.props.dispatch('scrollToNext');
   }, 200);
 
+  private handleWheel = (ev: WheelEvent) => {
+    const currentTarget = ev.currentTarget as HTMLElement;
+    ev.preventDefault();
+
+    currentTarget.scrollTop += ev.deltaY;
+    currentTarget.scrollLeft += ev.deltaX;
+  };
+
   private handleScroll = (ev: UIEvent) => {
     const { scrollLeft, scrollTop, scrollHeight, clientHeight } = ev.target as HTMLElement;
     const { dispatch, eventBus, side } = this.props;
@@ -457,6 +465,7 @@ class BodyAreaComp extends Component<Props> {
         style={areaStyle}
         onScroll={this.handleScroll}
         onMouseDown={this.handleMouseDown}
+        onWheel={this.handleWheel}
         ref={(el) => {
           this.el = el;
         }}


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed flickering new rows when scrolling.
  * I don't know the exact reason, but it seems that the problem occurred as the browser did some performance optimizations, etc when automatically transitioning from the `wheel` event to the `scroll` event.
  * Therefore, it has been modified to prevent the `wheel` event from automatically generating the `scroll` event, and to force the `scroll` event to occur by assigning the scroll value of the target element.

**As-Is**
![](https://user-images.githubusercontent.com/41339744/200213951-18da3db6-ce10-4696-90fd-2836055a65a4.gif)

**To-Be**
![](https://user-images.githubusercontent.com/41339744/200214077-54f2d977-677d-4cd3-99e1-1b7152ceaafd.gif)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
