### PR TITLE
perf: improve performance of setRows

### DIFF
--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -902,7 +902,7 @@ export function setRows(store: Store, rows: OptRow[]) {
     }
   });
 
-  createdRowInfos.forEach(({ row, orgRow }) => {
+  createdRowInfos.forEach(({ row }) => {
     const { rawRow, prevRow } = row;
 
     if (prevRow && isRowSpanEnabled(sortState, column)) {
@@ -910,7 +910,6 @@ export function setRows(store: Store, rows: OptRow[]) {
     }
 
     getDataManager(id).push('UPDATE', rawRow);
-    updateSummaryValueByRow(store, rawRow, { type: 'SET', orgRow });
   });
 
   sortByCurrentState(store);
@@ -921,6 +920,7 @@ export function setRows(store: Store, rows: OptRow[]) {
   });
 
   updateRowSpan(store);
+  updateAllSummaryValues(store);
 }
 
 export function moveRow(store: Store, rowKey: RowKey, targetIndex: number) {

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -896,19 +896,15 @@ export function setRows(store: Store, rows: OptRow[]) {
   });
   spliceContinuousRowInfos(data, continuousRowInfo);
 
-  createdRowInfos.forEach(({ rowIndex }) => {
-    if (isBetween(rowIndex, rowRange[0], rowRange[1])) {
-      makeObservable(store, rowIndex, false, true);
-    }
-  });
+  createdRowInfos
+    .filter(({ rowIndex }) => isBetween(rowIndex, rowRange[0], rowRange[1]))
+    .forEach(({ rowIndex }) => makeObservable(store, rowIndex, false, true));
 
-  createdRowInfos.forEach(({ row }) => {
-    const { prevRow } = row;
-
-    if (prevRow && isRowSpanEnabled(sortState, column)) {
-      updateRowSpanWhenAppending(rawData, prevRow, false);
-    }
-  });
+  if (isRowSpanEnabled(sortState, column)) {
+    createdRowInfos
+      .filter(({ row: { prevRow } }) => !!prevRow)
+      .forEach(({ row: { prevRow } }) => updateRowSpanWhenAppending(rawData, prevRow, false));
+  }
 
   getDataManager(id).push(
     'UPDATE',

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -239,7 +239,7 @@ export function setValue(
     updateHeightsWithFilteredData(store);
   });
   updateSummaryValueByCell(store, columnName, { orgValue, value });
-  getDataManager(id).push('UPDATE', targetRow);
+  getDataManager(id).push('UPDATE', [targetRow]);
 
   if (!isEmpty(rowSpanMap) && rowSpanMap[columnName] && isRowSpanEnabled(sortState, column)) {
     const { spanCount } = rowSpanMap[columnName];
@@ -247,7 +247,7 @@ export function setValue(
     for (let count = 1; count < spanCount; count += 1) {
       rawData[rowIndex + count][columnName] = value;
       updateSummaryValueByCell(store, columnName, { orgValue, value });
-      getDataManager(id).push('UPDATE', rawData[rowIndex + count]);
+      getDataManager(id).push('UPDATE', [rawData[rowIndex + count]]);
     }
   }
   setAutoResizingColumnWidths(store);
@@ -350,7 +350,7 @@ export function setColumnValues(
         value,
       });
       targetRow[columnName] = value;
-      getDataManager(id).push('UPDATE', targetRow);
+      getDataManager(id).push('UPDATE', [targetRow]);
     }
   });
   updateSummaryValueByColumn(store, columnName, { value });
@@ -596,7 +596,7 @@ export function appendRow(store: Store, row: OptRow, options: OptAppendRow) {
     updateRowSpan(store);
   }
 
-  getDataManager(id).push('CREATE', rawRow, inserted);
+  getDataManager(id).push('CREATE', [rawRow], inserted);
   updateSummaryValueByRow(store, rawRow, { type: 'APPEND' });
   postUpdateAfterManipulation(store, at, 'DONE', [rawRow]);
 }
@@ -635,7 +635,7 @@ export function removeRow(store: Store, rowKey: RowKey, options: OptRemoveRow) {
     updateSortKey(data, removedRow.sortKey + 1, false);
   }
 
-  getDataManager(id).push('DELETE', removedRow);
+  getDataManager(id).push('DELETE', [removedRow]);
   updateSummaryValueByRow(store, removedRow, { type: 'REMOVE' });
   postUpdateAfterManipulation(store, rowIndex, getLoadingState(rawData));
 }
@@ -831,7 +831,7 @@ export function setRow(store: Store, rowIndex: number, row: OptRow) {
     updateRowSpanWhenAppending(rawData, prevRow, false);
   }
 
-  getDataManager(id).push('UPDATE', rawRow);
+  getDataManager(id).push('UPDATE', [rawRow]);
 
   setTimeout(() => {
     updateHeightsWithFilteredData(store);
@@ -903,14 +903,17 @@ export function setRows(store: Store, rows: OptRow[]) {
   });
 
   createdRowInfos.forEach(({ row }) => {
-    const { rawRow, prevRow } = row;
+    const { prevRow } = row;
 
     if (prevRow && isRowSpanEnabled(sortState, column)) {
       updateRowSpanWhenAppending(rawData, prevRow, false);
     }
-
-    getDataManager(id).push('UPDATE', rawRow);
   });
+
+  getDataManager(id).push(
+    'UPDATE',
+    createdRowInfos.map(({ row }) => row.rawRow)
+  );
 
   sortByCurrentState(store);
   postUpdateAfterManipulation(store, createdRowInfos[0].rowIndex, 'DONE');
@@ -950,7 +953,7 @@ export function moveRow(store: Store, rowKey: RowKey, targetIndex: number) {
 
   resetSortKey(data, minIndex);
   updateRowNumber(store, minIndex);
-  getDataManager(id).push('UPDATE', rawRow, true);
+  getDataManager(id).push('UPDATE', [rawRow], true);
 }
 
 export function scrollToNext(store: Store) {
@@ -998,7 +1001,7 @@ export function appendRows(store: Store, inputData: OptRow[]) {
   resetSortKey(data, startIndex);
   sortByCurrentState(store);
   updateHeights(store);
-  rawData.forEach((rawRow) => getDataManager(id).push('CREATE', rawRow));
+  rawData.forEach((rawRow) => getDataManager(id).push('CREATE', [rawRow]));
   postUpdateAfterManipulation(store, startIndex, 'DONE', rawData);
   updateRowSpan(store);
 }
@@ -1022,7 +1025,7 @@ export function removeRows(store: Store, targetRows: RemoveTargetRows) {
         updateRowSpanWhenRemoving(rawData, removedRow, nextRow, false);
       }
     }
-    getDataManager(id).push('DELETE', removedRow);
+    getDataManager(id).push('DELETE', [removedRow]);
   });
 
   resetSortKey(data, 0);

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -21,6 +21,7 @@ import {
   silentSplice,
   isNil,
   last,
+  isBetween,
 } from '../helper/common';
 import { createViewRow, createData, setRowRelationListItems, createRawRow } from '../store/data';
 import { notify, isObservable, batchObserver, asyncInvokeObserver } from '../helper/observable';
@@ -850,8 +851,9 @@ function spliceContinuousRowInfos(data: Data, continuousRowInfo: ContinuousRowIn
 }
 
 export function setRows(store: Store, rows: OptRow[]) {
-  const { data, column, id } = store;
+  const { data, column, id, viewport } = store;
   const { rawData, sortState } = data;
+  const { rowRange } = viewport;
 
   const sortedIndexedRows = rows
     .map((row) => {
@@ -894,8 +896,10 @@ export function setRows(store: Store, rows: OptRow[]) {
   });
   spliceContinuousRowInfos(data, continuousRowInfo);
 
-  createdRowInfos.forEach(({ rowIndex }, index) => {
-    makeObservable(store, rowIndex, index !== createdRowInfos.length - 1, true);
+  createdRowInfos.forEach(({ rowIndex }) => {
+    if (isBetween(rowIndex, rowRange[0], rowRange[1])) {
+      makeObservable(store, rowIndex, false, true);
+    }
   });
 
   createdRowInfos.forEach(({ row, orgRow }) => {

--- a/packages/toast-ui.grid/src/dispatch/keyboard.ts
+++ b/packages/toast-ui.grid/src/dispatch/keyboard.ts
@@ -281,7 +281,7 @@ export function updateDataByKeyMap(store: Store, origin: Origin, changeInfo: Cha
     const targetRowIndex = changeValue();
     if (index !== targetRowIndex) {
       index = targetRowIndex;
-      manager.push('UPDATE', filteredRawData[index]);
+      manager.push('UPDATE', [filteredRawData[index]]);
     }
   });
   updateAllSummaryValues(store);

--- a/packages/toast-ui.grid/src/dispatch/tree.ts
+++ b/packages/toast-ui.grid/src/dispatch/tree.ts
@@ -372,7 +372,7 @@ export function appendTreeRow(
 
   const rowHeights = rawRows.map((rawRow) => {
     changeTreeRowsCheckedState(store, rawRow.rowKey, rawRow._attributes.checked);
-    getDataManager(id).push(modificationType, rawRow, true);
+    getDataManager(id).push(modificationType, [rawRow], true);
 
     return getRowHeight(rawRow, dimension.rowHeight);
   });
@@ -411,7 +411,7 @@ export function removeTreeRow(store: Store, rowKey: RowKey, movingRow?: boolean)
   heights.splice(startIdx, deleteCount);
 
   for (let i = removedRows.length - 1; i >= 0; i -= 1) {
-    getDataManager(id).push(modificationType, removedRows[i]);
+    getDataManager(id).push(modificationType, [removedRows[i]]);
   }
   postUpdateAfterManipulation(store, startIdx, rawData);
 }
@@ -457,8 +457,8 @@ export function moveTreeRow(
     removeTreeRow(store, rowKey, true);
     const originRow = getOriginObject(row as Observable<Row>);
 
-    getDataManager(id).push('UPDATE', targetRow, true);
-    getDataManager(id).push('UPDATE', row, true);
+    getDataManager(id).push('UPDATE', [targetRow], true);
+    getDataManager(id).push('UPDATE', [row], true);
 
     if (options.appended) {
       appendTreeRow(store, originRow, { parentRowKey: targetRow.rowKey, movingRow: true });

--- a/packages/toast-ui.grid/types/dataSource/index.d.ts
+++ b/packages/toast-ui.grid/types/dataSource/index.d.ts
@@ -108,7 +108,7 @@ export interface ModifiedDataManager {
   getAllModifiedData: (options: ModifiedRowsOptions) => ModifiedRows;
   isModified: () => boolean;
   isModifiedByType: (type: ModificationTypeCode) => boolean;
-  push: (type: ModificationTypeCode, row: Row, mixed?: boolean) => void;
+  push: (type: ModificationTypeCode, row: Row[], mixed?: boolean) => void;
   clearSpecificRows: (rowMap: MutationParams) => void;
   clear: (type: RequestTypeCode) => void;
   clearAll: () => void;


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

Improved performance of the setRows API.
1. modified to only make data within the viewport responsive, not all data set by setRows.
2. modified to update summaryData after all data is set, rather than updating summaryData for each row that is set.
3. modifiedDataManager to handle modified data as an array.

This should result in the following performance improvements

Test environment: macOS Ventura 13.1, Chrome 110, 1 million data (10000 rows, 100 columns), using summaryData for all columns

1. using the setRow API: 3,586,784 ms on average (about 1 hour)
2. using setRows API (before performance improvements): 595,712 ms on average (about 10 minutes) 
3. using the setRows API (after performance improvements): 595 ms on average (about 0.6 seconds)

This is a 6028x performance improvement over using the setRow API and a 1001x performance improvement over before the performance improvement.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
