### PR TITLE
fix: filter input not reset on clear filter

### DIFF
--- a/packages/toast-ui.grid/src/dispatch/filter.ts
+++ b/packages/toast-ui.grid/src/dispatch/filter.ts
@@ -152,6 +152,7 @@ export function clearActiveFilterState(store: Store) {
   const activeFilterState = filterLayerState.activeFilterState!;
   activeFilterState.state = [];
   unfilter(store, activeFilterState.columnName);
+  notify(filterLayerState, 'activeFilterState');
 }
 
 export function setActiveFilterState(store: Store, state: FilterState, filterIndex: number) {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

Fixed an issue where the `input` element of a filter was not initialized when cleared without applying the filter.

Unlike the `data` in the store, the `filterLayerState` is not observable. However, the TOAST UI Grid does not unfilter when no filter is applied. After all, the filter in the data does not change, so resetting the `filterLayeState` does not trigger a re-render.

To properly reflect a resetting `filterLayerState`, I've changed it to call a `notify` function to notify that the store has changed, causing a re-render.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
