### PR TITLE
fix: not work correctly when the row span is 1 (fix #1767)

### DIFF
--- a/packages/toast-ui.grid/src/dispatch/rowSpan.ts
+++ b/packages/toast-ui.grid/src/dispatch/rowSpan.ts
@@ -23,7 +23,10 @@ export function updateRowSpanWhenAppending(data: Row[], prevRow: Row, extendPrev
       const startOffset = keyRow || extendPrevRowSpan ? 1 : -count + 1;
 
       // keep rowSpan state when appends row in the middle of rowSpan
-      if (mainRowSpan.spanCount > startOffset) {
+      if (
+        mainRowSpan.spanCount > startOffset ||
+        (mainRowSpan.spanCount === 1 && startOffset === 1)
+      ) {
         mainRowSpan.count += 1;
         mainRowSpan.spanCount += 1;
 

--- a/packages/toast-ui.grid/src/store/data.ts
+++ b/packages/toast-ui.grid/src/store/data.ts
@@ -354,7 +354,8 @@ function createSubRowSpan(prevRowSpanMap: RowSpanMap) {
   Object.keys(prevRowSpanMap).forEach((columnName) => {
     const prevRowSpan = prevRowSpanMap[columnName];
     const { mainRowKey, count, spanCount } = prevRowSpan;
-    if (spanCount > 1 - count) {
+
+    if (spanCount > 1 && spanCount > 1 - count) {
       const subRowCount = count >= 0 ? -1 : count - 1;
       subRowSpanMap[columnName] = createRowSpan(false, mainRowKey, subRowCount, spanCount);
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed a problem that does not work correctly when row span is 1.
  * This was caused by trying to apply row span to the next row even though rowSpan was 1.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
