### PR TITLE
perf: large data with tree grid

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/tree.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/tree.spec.ts
@@ -475,7 +475,7 @@ describe('appendTreeRow()', () => {
       cy.getCell(7, 'c1').should('have.text', 'c');
     });
 
-    it.only('specific parent that internal type.', () => {
+    it('specific parent that internal type.', () => {
       cy.gridInstance().invoke('appendTreeRow', appendedData, { parentRowKey: 0 });
       cy.gridInstance().invoke('expand', 0, true);
       cy.gridInstance().invoke('expand', 5, true);

--- a/packages/toast-ui.grid/cypress/integration/tree.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/tree.spec.ts
@@ -1,13 +1,13 @@
-import { RowKey, CellValue } from '@t/store/data';
+import { CellValue, RowKey } from '@t/store/data';
 import { OptColumn, OptGrid, OptRow } from '@t/options';
 import GridEvent from '@/event/gridEvent';
 import { CellRenderer, CellRendererProps } from '@t/renderer';
 import { cls } from '../../src/helper/dom';
 import {
   assertGridHasRightRowNumber,
+  assertModifiedRowsLength,
   assertToggleButtonCollapsed,
   assertToggleButtonExpanded,
-  assertModifiedRowsLength,
 } from '../helper/assert';
 import { dragAndDropColumn, dragAndDropRow } from '../helper/util';
 
@@ -475,9 +475,10 @@ describe('appendTreeRow()', () => {
       cy.getCell(7, 'c1').should('have.text', 'c');
     });
 
-    it('specific parent that internal type.', () => {
+    it.only('specific parent that internal type.', () => {
       cy.gridInstance().invoke('appendTreeRow', appendedData, { parentRowKey: 0 });
       cy.gridInstance().invoke('expand', 0, true);
+      cy.gridInstance().invoke('expand', 5, true);
 
       cy.getCell(5, 'c1').should('have.text', 'a');
       cy.getCell(6, 'c1').should('have.text', 'b');

--- a/packages/toast-ui.grid/src/dispatch/tree.ts
+++ b/packages/toast-ui.grid/src/dispatch/tree.ts
@@ -1,43 +1,49 @@
 import { Row, RowKey } from '@t/store/data';
 import { Store } from '@t/store';
-import { OptRow, OptAppendTreeRow, OptMoveRow } from '@t/options';
+import { OptAppendTreeRow, OptMoveRow, OptRow } from '@t/options';
 import { Column, ColumnInfo } from '@t/store/column';
 import { ColumnCoords } from '@t/store/columnCoords';
 import { Dimension } from '@t/store/dimension';
 import { createViewRow } from '../store/data';
 import {
-  getRowHeight,
   findIndexByRowKey,
   findRowByRowKey,
   getLoadingState,
-  isSorted,
+  getRowHeight,
   isFiltered,
+  isSorted,
 } from '../query/data';
-import { notify, batchObserver, getOriginObject, Observable } from '../helper/observable';
+import {
+  batchObserver,
+  getOriginObject,
+  notify,
+  Observable,
+  unobservable,
+} from '../helper/observable';
 import { getDataManager } from '../instance';
 import {
   isUpdatableRowAttr,
-  setLoadingState,
-  updateRowNumber,
   setCheckedAllRows,
+  setLoadingState,
   uncheck,
+  updateRowNumber,
 } from './data';
 import {
-  getParentRow,
+  getChildRowKeys,
+  getDepth,
   getDescendantRows,
+  getParentRow,
   getStartIndexToAppendRow,
+  isExpanded,
+  isLeaf,
+  isRootChildRow,
   traverseAncestorRows,
   traverseDescendantRows,
-  getChildRowKeys,
-  isLeaf,
-  isExpanded,
-  isRootChildRow,
-  getDepth,
 } from '../query/tree';
 import { getEventBus } from '../event/eventBus';
 import GridEvent from '../event/gridEvent';
 import { flattenTreeData, getTreeIndentWidth } from '../store/helper/tree';
-import { findProp, findPropIndex, removeArrayItem, some, silentSplice } from '../helper/common';
+import { findProp, findPropIndex, removeArrayItem, silentSplice, some } from '../helper/common';
 import { cls, getTextWidth } from '../helper/dom';
 import { fillMissingColumnData } from './lazyObservable';
 import { getColumnSide } from '../query/column';
@@ -218,6 +224,7 @@ function collapse(store: Store, row: Row, recursive?: boolean) {
     }
 
     changeHiddenAttr(childRow, true);
+    unobservable(childRow._attributes.tree!, ['hidden']);
 
     if (!isLeaf(childRow)) {
       if (recursive) {

--- a/packages/toast-ui.grid/src/helper/observable.ts
+++ b/packages/toast-ui.grid/src/helper/observable.ts
@@ -1,5 +1,5 @@
 import { Dictionary } from '@t/options';
-import { hasOwnProp, isObject, forEachObject, last, isEmpty, isFunction, isNull } from './common';
+import { forEachObject, hasOwnProp, isEmpty, isFunction, isNull, isObject, last } from './common';
 import { patchArrayMethods } from './array';
 
 type BooleanSet = Dictionary<boolean>;
@@ -184,6 +184,20 @@ export function partialObservable<T extends Dictionary<any>>(obj: T, key: string
   makeObservableData(obj, obj, key, storage, propObserverIdSetMap);
 }
 
+export function unobservable<T extends Dictionary<any>>(obj: T, keys: Array<keyof T> = []) {
+  if (isObservable(obj)) {
+    keys.forEach((key) => {
+      const value = obj[key];
+
+      delete obj[key];
+
+      obj[key] = value;
+    });
+
+    delete obj.__storage__;
+  }
+}
+
 export function observable<T extends Dictionary<any>>(obj: T, sync = false): Observable<T> {
   if (Array.isArray(obj)) {
     throw new Error('Array object cannot be Reactive');
@@ -198,7 +212,7 @@ export function observable<T extends Dictionary<any>>(obj: T, sync = false): Obs
   const resultObj = {} as T;
 
   Object.defineProperties(resultObj, {
-    __storage__: { value: storage },
+    __storage__: { value: storage, configurable: true },
     __propObserverIdSetMap__: { value: propObserverIdSetMap },
   });
 

--- a/packages/toast-ui.grid/src/helper/observable.ts
+++ b/packages/toast-ui.grid/src/helper/observable.ts
@@ -186,15 +186,13 @@ export function partialObservable<T extends Dictionary<any>>(obj: T, key: string
 
 export function unobservable<T extends Dictionary<any>>(obj: T, keys: Array<keyof T> = []) {
   if (isObservable(obj)) {
-    keys.forEach((key) => {
-      const value = obj[key];
+    const originObject = getOriginObject(obj) as Observable<T>;
 
+    keys.forEach((key) => {
       delete obj[key];
 
-      obj[key] = value;
+      obj[key] = originObject[key];
     });
-
-    delete obj.__storage__;
   }
 }
 

--- a/packages/toast-ui.grid/src/view/bodyRow.tsx
+++ b/packages/toast-ui.grid/src/view/bodyRow.tsx
@@ -1,5 +1,5 @@
-import { h, Component } from 'preact';
-import { ViewRow, RowKey } from '@t/store/data';
+import { Component, h } from 'preact';
+import { RowKey, ViewRow } from '@t/store/data';
 import { ColumnInfo } from '@t/store/column';
 import { connect } from './hoc';
 import { cls } from '../helper/dom';
@@ -12,6 +12,7 @@ interface OwnProps {
   rowIndex: number;
   viewRow: ViewRow;
   columns: ColumnInfo[];
+  isVisible: boolean;
 }
 
 interface StoreProps {
@@ -52,11 +53,13 @@ class BodyRowComp extends Component<Props> {
     autoRowHeight,
     hoveredRowKey,
     focusedRowKey,
+    isVisible,
   }: Props) {
     const isOddRow = rowIndex % 2 === 0;
 
     return (
-      rowHeight > 0 && (
+      rowHeight > 0 &&
+      isVisible && (
         <tr
           style={{
             height: rowHeight,

--- a/packages/toast-ui.grid/src/view/bodyRows.tsx
+++ b/packages/toast-ui.grid/src/view/bodyRows.tsx
@@ -1,10 +1,10 @@
-import { h, Component } from 'preact';
+import { Component, h } from 'preact';
 import { Side } from '@t/store/focus';
-import { ViewRow } from '@t/store/data';
+import { Row, RowKey, ViewRow } from '@t/store/data';
 import { ColumnInfo } from '@t/store/column';
 import { BodyRow } from './bodyRow';
 import { BodyDummyRow } from './bodyDummyRow';
-import { shallowEqual, range } from '../helper/common';
+import { range, shallowEqual } from '../helper/common';
 import { connect } from './hoc';
 import { DispatchProps } from '../dispatch/create';
 
@@ -13,21 +13,40 @@ interface OwnProps {
 }
 
 interface StoreProps {
+  rawData: Row[];
   rows: ViewRow[];
   rowIndexOffset: number;
   columns: ColumnInfo[];
   dummyRowCount: number;
+  hasTreeColumn: boolean;
 }
 
 type Props = OwnProps & StoreProps & DispatchProps;
 
 class BodyRowsComp extends Component<Props> {
+  private getVisibleStateOfRows({ rawData, rows }: Pick<Props, 'rows' | 'rawData'>) {
+    const rowKeys = rows.map(({ rowKey }) => rowKey);
+
+    return rawData.reduce((acc, { rowKey, _attributes }) => {
+      if (!rowKeys.includes(rowKey)) {
+        return acc;
+      }
+
+      acc[rowKey] = !_attributes.tree?.hidden;
+
+      return acc;
+    }, {} as Record<RowKey, boolean>);
+  }
+
   public shouldComponentUpdate(nextProps: Props) {
     return !shallowEqual(nextProps, this.props);
   }
 
-  public render({ rows, rowIndexOffset, columns, dummyRowCount }: Props) {
+  public render({ rawData, rows, rowIndexOffset, columns, dummyRowCount, hasTreeColumn }: Props) {
     const columnNames = columns.map(({ name }) => name);
+
+    const visibleStateOfRows = hasTreeColumn ? this.getVisibleStateOfRows({ rows, rawData }) : null;
+
     return (
       <tbody>
         {rows.map((row, index) => (
@@ -36,6 +55,7 @@ class BodyRowsComp extends Component<Props> {
             rowIndex={index + rowIndexOffset}
             viewRow={row}
             columns={columns}
+            isVisible={visibleStateOfRows?.[row.rowKey] ?? true}
           />
         ))}
         {range(dummyRowCount).map((index) => (
@@ -51,8 +71,10 @@ class BodyRowsComp extends Component<Props> {
 }
 
 export const BodyRows = connect<StoreProps, OwnProps>(({ viewport, column, data }, { side }) => ({
+  rawData: data.filteredRawData,
   rowIndexOffset: viewport.rowRange[0] - data.pageRowRange[0],
   rows: viewport.rows,
   columns: side === 'L' ? column.visibleColumnsBySideWithRowHeader.L : viewport.columns,
   dummyRowCount: viewport.dummyRowCount,
+  hasTreeColumn: !!column.treeColumnName,
 }))(BodyRowsComp);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Improved performance when expanding/collapsing in a tree grid of large data.
  * Improved rendering performance by preventing the rendering of child rows that are collapsed and therefore invisible.
    * Previously, it rendered more than the number of collapsed child rows * the number of columns.
  * When collapsing a tree, unobserve the tree property of child rows to avoid unnecessarily performing observable data behavior later on.
* It gave about a 2000x performance improvement.(from about 300000ms to about 150ms)
  * Test environment
    * Large children data: 10000 rows, 50 columns
    * Make all child row to observable by scroll to bottom.
    * M1 Pro, 16GB, Mac OS 13.1, Chrome 113

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
