### PR TITLE
fix: missing update history in DataManger

### DIFF
--- a/packages/toast-ui.grid/src/dataSource/manager/modifiedDataManager.ts
+++ b/packages/toast-ui.grid/src/dataSource/manager/modifiedDataManager.ts
@@ -1,26 +1,26 @@
 import {
-  ModifiedDataMap,
   ModificationTypeCode,
-  ModifiedRowsOptions,
   ModifiedDataManager,
+  ModifiedDataMap,
   ModifiedRows,
-  RequestTypeCode,
+  ModifiedRowsOptions,
   MutationParams,
+  RequestTypeCode,
 } from '@t/dataSource';
 import { OptRow } from '@t/options';
 import { Row, RowKey } from '@t/store/data';
 import {
-  someProp,
   findIndex,
-  isUndefined,
-  omit,
-  isObject,
   forEachObject,
   isEmpty,
+  isObject,
+  isUndefined,
   last,
+  omit,
+  someProp,
 } from '../../helper/common';
 import { getOriginObject, Observable } from '../../helper/observable';
-import { getOmittedInternalProp, changeRawDataToOriginDataForTree } from '../../query/data';
+import { changeRawDataToOriginDataForTree, getOmittedInternalProp } from '../../query/data';
 
 type ParamNameMap = { [type in ModificationTypeCode]: string };
 
@@ -85,10 +85,14 @@ export function createManager(): ModifiedDataManager {
           return acc;
         }
 
-        const lastContinuousRowIndices = !acc ? acc : last(acc);
-        const lastRowIndex = !lastContinuousRowIndices ? -1 : last(lastContinuousRowIndices);
+        const lastContinuousRowIndices = last(acc) ?? [];
+        const lastRowIndex = last(lastContinuousRowIndices)?.rowIndex;
 
-        if (isUndefined(lastContinuousRowIndices) || rowIndex - lastRowIndex !== 1) {
+        if (
+          isUndefined(lastContinuousRowIndices) ||
+          isUndefined(lastRowIndex) ||
+          rowIndex - lastRowIndex !== 1
+        ) {
           acc.push([indexedRow]);
         } else {
           lastContinuousRowIndices.push(indexedRow);
@@ -97,20 +101,22 @@ export function createManager(): ModifiedDataManager {
         return acc;
       }, []);
 
-    sortedContinuousIndexedRows.forEach((indexedRows) => {
+    sortedContinuousIndexedRows.reduce((accLength, indexedRows) => {
       const startIndex = indexedRows[0].rowIndex;
-      const lastIndex = last(indexedRows).rowIndex;
+      const currentLength = last(indexedRows).rowIndex - startIndex + 1;
 
       if (isUndefined(rows)) {
-        dataMap[type].splice(startIndex, lastIndex - startIndex + 1);
+        dataMap[type].splice(startIndex - accLength, currentLength);
       } else {
         dataMap[type].splice(
           startIndex,
-          lastIndex - startIndex + 1,
+          currentLength,
           ...indexedRows.reduce((acc: Row[], { row }) => (!row ? acc : [...acc, row]), [])
         );
       }
-    });
+
+      return accLength + currentLength;
+    }, 0);
   };
   const spliceAll = (rowKey: RowKey, row?: Row) => {
     splice('CREATE', [rowKey], !row ? row : [row]);

--- a/packages/toast-ui.grid/src/dataSource/manager/modifiedDataManager.ts
+++ b/packages/toast-ui.grid/src/dataSource/manager/modifiedDataManager.ts
@@ -101,12 +101,14 @@ export function createManager(): ModifiedDataManager {
         return acc;
       }, []);
 
-    sortedContinuousIndexedRows.reduce((accLength, indexedRows) => {
+    let accumulatedLength = 0;
+
+    sortedContinuousIndexedRows.forEach((indexedRows) => {
       const startIndex = indexedRows[0].rowIndex;
       const currentLength = last(indexedRows).rowIndex - startIndex + 1;
 
       if (isUndefined(rows)) {
-        dataMap[type].splice(startIndex - accLength, currentLength);
+        dataMap[type].splice(startIndex - accumulatedLength, currentLength);
       } else {
         dataMap[type].splice(
           startIndex,
@@ -115,8 +117,8 @@ export function createManager(): ModifiedDataManager {
         );
       }
 
-      return accLength + currentLength;
-    }, 0);
+      accumulatedLength += currentLength;
+    });
   };
   const spliceAll = (rowKey: RowKey, row?: Row) => {
     splice('CREATE', [rowKey], !row ? row : [row]);

--- a/packages/toast-ui.grid/src/helper/common.ts
+++ b/packages/toast-ui.grid/src/helper/common.ts
@@ -265,7 +265,7 @@ export function range(end: number) {
   return arr;
 }
 
-export function last<T>(arr: T[]) {
+export function last(arr: any[]) {
   return arr[arr.length - 1];
 }
 

--- a/packages/toast-ui.grid/src/helper/common.ts
+++ b/packages/toast-ui.grid/src/helper/common.ts
@@ -265,7 +265,7 @@ export function range(end: number) {
   return arr;
 }
 
-export function last(arr: any[]) {
+export function last<T>(arr: T[]) {
   return arr[arr.length - 1];
 }
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed an issue where update history in DataManger was missing when using the setRows API.
  * This issue was caused by two mistakes.
    1. To efficiently update the update history, when looking for consecutive row indices, we checked for consecutive using the object itself, not the `rowIndex` property of the `IndexedRow` object.
    2. When removing old update history using consecutive rowIndexes of the rows being updated, the starting index was set without considering the number of previously deleted elements, resulting in incorrectly deleting old update history.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
