### PR TITLE
fix: replace wrong rows when use setRows API with filter

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/data.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/data.spec.ts
@@ -878,6 +878,16 @@ describe.only('setRows()', () => {
 
     assertHeaderCheckboxStatus(false);
   });
+
+  it('should replace rows properly when it is filtered', () => {
+    createGrid();
+    cy.gridInstance().invoke('setFilter', 'name', 'select');
+    invokeFilter('name', [{ code: 'eq', value: 'Lee' }]);
+
+    cy.gridInstance().invoke('setRows', [{ rowKey: 1, name: 'Han', age: 29 }]);
+
+    cy.gridInstance().invoke('getFilteredData').should('have.length', 0);
+  });
 });
 
 describe('moveRow()', () => {

--- a/packages/toast-ui.grid/cypress/integration/data.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/data.spec.ts
@@ -767,7 +767,7 @@ describe('setRow()', () => {
   });
 });
 
-describe.only('setRows()', () => {
+describe('setRows()', () => {
   it('should replace rows', () => {
     createGrid();
 

--- a/packages/toast-ui.grid/cypress/integration/data.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/data.spec.ts
@@ -858,6 +858,9 @@ describe('setRows()', () => {
     createGrid({ rowHeaders: ['checkbox'] });
 
     cy.gridInstance().invoke('checkAll');
+
+    assertCheckboxStatus(true);
+
     cy.gridInstance().invoke('setRows', [
       {
         rowKey: 1,
@@ -879,7 +882,7 @@ describe('setRows()', () => {
     assertHeaderCheckboxStatus(false);
   });
 
-  it('should replace rows properly when it is filtered', () => {
+  it('should replace filtered rows correctly when a filter is applied', () => {
     createGrid();
     cy.gridInstance().invoke('setFilter', 'name', 'select');
     invokeFilter('name', [{ code: 'eq', value: 'Lee' }]);

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -857,7 +857,7 @@ export function setRows(store: Store, rows: OptRow[]) {
 
   const sortedIndexedRows = rows
     .map((row) => {
-      const rowIndex = findIndexByRowKey(data, column, id, row.rowKey as RowKey);
+      const rowIndex = findIndexByRowKey(data, column, id, row.rowKey as RowKey, false);
       const orgRow = rawData[rowIndex];
 
       removeUniqueInfoMap(id, orgRow, column);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed an issue where using the setRows API when filtering would change the wrong row and create duplicate rows.
  * It was caused by looking for the row index of the row to be changed in unfiltered data and finding the wrong row index.

**As-Is**
![](https://github.com/nhn/tui.grid/assets/41339744/a98743fd-6d04-4d76-9e2a-bf69ff75402d)


**To-Be**
![](https://github.com/nhn/tui.grid/assets/41339744/9047c697-48e7-4c0b-a9b6-f58a647866bd)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
