### PR TITLE
fix: set wrong select filter when previous filter data disappear by replacing

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/filter.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/filter.spec.ts
@@ -1,7 +1,7 @@
 import { FormatterProps } from '@t/store/column';
 import { cls } from '@/helper/dom';
 import { OptRow } from '@t/options';
-import { invokeFilter, clickFilterBtn, inputFilterValue } from '../helper/util';
+import { clickFilterBtn, inputFilterValue, invokeFilter } from '../helper/util';
 
 const GRID_WIDTH = 500;
 
@@ -403,6 +403,21 @@ describe('apply filter (type: select)', () => {
       ['player6', 'Lee'],
       ['player7', 'Yoo'],
       ['player8', 'Lim'],
+    ]);
+  });
+
+  it.only('should set filter properly when filter change after all rows for previous filter are disappear.', () => {
+    cy.gridInstance().invoke('resetData', data.slice(0, 3));
+
+    invokeFilter('id', [{ code: 'eq', value: 'player1' }]);
+
+    cy.gridInstance().invoke('setRow', 0, { ...data[0], id: data[1].id });
+
+    applyFilterBySelectUI(1);
+
+    cy.getRsideBody().should('have.cellData', [
+      ['player2', 'Choi'],
+      ['player2', 'Kim'],
     ]);
   });
 });

--- a/packages/toast-ui.grid/cypress/integration/filter.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/filter.spec.ts
@@ -406,7 +406,7 @@ describe('apply filter (type: select)', () => {
     ]);
   });
 
-  it.only('should set filter properly when filter change after all rows for previous filter are disappear.', () => {
+  it('should set filter properly when filter change after all rows for previous filter are disappear.', () => {
     cy.gridInstance().invoke('resetData', data.slice(0, 3));
 
     invokeFilter('id', [{ code: 'eq', value: 'player1' }]);

--- a/packages/toast-ui.grid/cypress/integration/filter.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/filter.spec.ts
@@ -406,7 +406,7 @@ describe('apply filter (type: select)', () => {
     ]);
   });
 
-  it('should set filter properly when filter change after all rows for previous filter are disappear.', () => {
+  it('should set filter to intended filter when filter change after all rows for previous filter are disappear.', () => {
     cy.gridInstance().invoke('resetData', data.slice(0, 3));
 
     invokeFilter('id', [{ code: 'eq', value: 'player1' }]);

--- a/packages/toast-ui.grid/src/dispatch/filter.ts
+++ b/packages/toast-ui.grid/src/dispatch/filter.ts
@@ -136,7 +136,11 @@ export function applyActiveFilterState(store: Store) {
 
   if (type === 'select') {
     const columnData = getUniqColumnData(data.rawData, column, columnName);
-    if (columnData.length === state.length) {
+    const updatedState = state.filter(({ value }) => columnData.includes(value));
+
+    filterLayerState.activeFilterState!.state = updatedState;
+
+    if (columnData.length === updatedState.length) {
       unfilter(store, columnName);
       return;
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed an issue where all rows for the current filter would disappear while filtering, and then applying another filter would cause the filter to be applied incorrectly.
  * It was caused by filter condition which disappeared due to data changes remaining in the filter state 

**As-Is**
![](https://github.com/nhn/tui.grid/assets/41339744/2774d5bb-3af8-450e-9a10-6c42c1aa8066)


**To-Be**
![](https://github.com/nhn/tui.grid/assets/41339744/172ab5ab-edb4-44a3-a47b-61c249422424)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
