### PR TITLE
fix: parent elements could not be scrolled when cursor above the grid

### DIFF
--- a/packages/toast-ui.grid/src/helper/dom.ts
+++ b/packages/toast-ui.grid/src/helper/dom.ts
@@ -360,3 +360,14 @@ export function getComputedFontStyle(selector: ClassNameType) {
 
   return `${fontWeight} ${fontSize} ${fontFamily}`;
 }
+
+export const isElementScrollable = (element: HTMLElement) => {
+  const { offsetHeight, offsetWidth, scrollHeight, scrollWidth, scrollTop, scrollLeft } = element;
+
+  return {
+    canScrollUp: scrollTop > 0,
+    canScrollDown: scrollTop + offsetHeight < scrollHeight,
+    canScrollLeft: scrollLeft > 0,
+    canScrollRight: scrollLeft + offsetWidth < scrollWidth,
+  };
+};


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed an issue where parent elements could not be scrolled when the cursor was above the grid.
  * This was caused by calling `preventDefault` regardless of whether the grid was scrollable or not.

**As-Is**
![](https://github.com/nhn/tui.grid/assets/41339744/2322c630-0d72-4e61-99c5-6394d4038d6a)

**To-Be**
![](https://github.com/nhn/tui.grid/assets/41339744/90424a97-ee91-455a-9553-5f2ed56b5714)


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
