### PR TITLE
fix: check/uncheck event emitted when multi check/uncheck via shift click

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/eventBus.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/eventBus.spec.ts
@@ -335,6 +335,55 @@ describe('rowHeader: checkbox', () => {
 
       cy.wrap(uncheckCallback).should('be.calledOnce');
     });
+
+    it(`checkBetween / uncheckBetween by ${type}`, () => {
+      cy.createGrid({
+        data: [...data, ...data],
+        columns,
+        draggable: true,
+        bodyHeight: 150,
+        width: 500,
+        rowHeaders: ['rowNum', 'checkbox'],
+      });
+
+      const checkCallback = cy.stub();
+      const uncheckCallback = cy.stub();
+
+      cy.getByCls('cell-row-header').get('input').eq(1).as('firstCheckbox');
+      cy.getByCls('cell-row-header').get('input').eq(2).as('secondCheckbox');
+      cy.getByCls('cell-row-header').get('input').eq(-1).as('lastCheckbox');
+
+      cy.gridInstance().invoke('on', 'check', checkCallback);
+      cy.gridInstance().invoke('on', 'uncheck', uncheckCallback);
+
+      if (type === 'UI') {
+        // In Cypress 4.9.0, there is no way to test Shift-click
+        // cy.get('@secondCheckbox').click();
+        // cy.get('@firstCheckbox').click();
+        // cy.get('@lastCheckbox').click({
+        //   shiftKey: true, // not available in Cypress 4.9.0
+        // });
+      } else {
+        cy.gridInstance().invoke('check', 1);
+        cy.gridInstance().invoke('checkBetween', 0, 3);
+
+        cy.wrap(checkCallback).should('be.calledWithMatch', { rowKeys: [0, 2, 3] });
+      }
+
+      if (type === 'UI') {
+        // In Cypress 4.9.0, there is no way to test Shift-click
+        // cy.get('@secondCheckbox').click();
+        // cy.get('@firstCheckbox').click();
+        // cy.get('@lastCheckbox').click({
+        //   shiftKey: true, // not available in Cypress 4.9.0
+        // });
+      } else {
+        cy.gridInstance().invoke('uncheck', 1);
+        cy.gridInstance().invoke('uncheckBetween', 0, 3);
+
+        cy.wrap(uncheckCallback).should('be.calledWithMatch', { rowKeys: [0, 2, 3] });
+      }
+    });
   });
 });
 

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -418,8 +418,8 @@ export function setCheckboxBetween(
   startRowKey: RowKey,
   endRowKey?: RowKey
 ) {
-  const { data, id } = store;
-  const { clickedCheckboxRowkey } = data;
+  const { data, column, id } = store;
+  const { clickedCheckboxRowkey, filteredRawData } = data;
   const targetRowKey = endRowKey || clickedCheckboxRowkey;
   const eventBus = getEventBus(id);
 
@@ -434,11 +434,23 @@ export function setCheckboxBetween(
     return;
   }
 
-  const range = getIndexRangeOfCheckbox(store, startRowKey, targetRowKey);
+  const prevCheckedCheckboxRowIndex = findIndexByRowKey(
+    data,
+    column,
+    id,
+    clickedCheckboxRowkey,
+    isFiltered(data)
+  );
+  let range = getIndexRangeOfCheckbox(store, startRowKey, targetRowKey);
+
+  range =
+    range[0] === prevCheckedCheckboxRowIndex ? [range[0] + 1, range[1]] : [range[0], range[1] - 1];
 
   const rowKeys: RowKey[] = [];
   for (let i = range[0]; i < range[1]; i += 1) {
-    rowKeys.push(getRowKeyByIndexWithPageRange(data, i));
+    if (filteredRawData[i]._attributes.checked !== value) {
+      rowKeys.push(getRowKeyByIndexWithPageRange(data, i));
+    }
   }
 
   const gridEvent = new GridEvent({ rowKeys });

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -443,8 +443,11 @@ export function setCheckboxBetween(
   );
   let range = getIndexRangeOfCheckbox(store, startRowKey, targetRowKey);
 
-  range =
-    range[0] === prevCheckedCheckboxRowIndex ? [range[0] + 1, range[1]] : [range[0], range[1] - 1];
+  if (range[0] === prevCheckedCheckboxRowIndex) {
+    range = [range[0] + 1, range[1]];
+  } else if (range[1] === prevCheckedCheckboxRowIndex) {
+    range = [range[0], range[1] - 1];
+  }
 
   const rowKeys: RowKey[] = [];
   for (let i = range[0]; i < range[1]; i += 1) {

--- a/packages/toast-ui.grid/src/query/data.ts
+++ b/packages/toast-ui.grid/src/query/data.ts
@@ -366,3 +366,34 @@ export function changeRawDataToOriginDataForTree(rawData: Row[]) {
     .filter((row) => isNil(row._attributes?.tree?.parentRowKey))
     .map((row) => changeRowToOriginRowForTree(row));
 }
+
+export function getCheckStateChangedRowkeysInRange(
+  store: Store,
+  checkState: boolean,
+  range: [number, number]
+) {
+  const { data, column, id } = store;
+  const { clickedCheckboxRowkey, filteredRawData } = data;
+  const prevCheckedCheckboxRowIndex = findIndexByRowKey(
+    data,
+    column,
+    id,
+    clickedCheckboxRowkey,
+    isFiltered(data)
+  );
+
+  if (range[0] === prevCheckedCheckboxRowIndex) {
+    range = [range[0] + 1, range[1]];
+  } else if (range[1] === prevCheckedCheckboxRowIndex) {
+    range = [range[0], range[1] - 1];
+  }
+
+  const rowKeys: RowKey[] = [];
+  for (let i = range[0]; i < range[1]; i += 1) {
+    if (filteredRawData[i]._attributes.checked !== checkState) {
+      rowKeys.push(getRowKeyByIndexWithPageRange(data, i));
+    }
+  }
+
+  return rowKeys;
+}

--- a/packages/toast-ui.grid/src/query/data.ts
+++ b/packages/toast-ui.grid/src/query/data.ts
@@ -372,21 +372,8 @@ export function getCheckStateChangedRowkeysInRange(
   checkState: boolean,
   range: [number, number]
 ) {
-  const { data, column, id } = store;
-  const { clickedCheckboxRowkey, filteredRawData } = data;
-  const prevCheckedCheckboxRowIndex = findIndexByRowKey(
-    data,
-    column,
-    id,
-    clickedCheckboxRowkey,
-    isFiltered(data)
-  );
-
-  if (range[0] === prevCheckedCheckboxRowIndex) {
-    range = [range[0] + 1, range[1]];
-  } else if (range[1] === prevCheckedCheckboxRowIndex) {
-    range = [range[0], range[1] - 1];
-  }
+  const { data } = store;
+  const { filteredRawData } = data;
 
   const rowKeys: RowKey[] = [];
   for (let i = range[0]; i < range[1]; i += 1) {

--- a/packages/toast-ui.grid/types/event/index.d.ts
+++ b/packages/toast-ui.grid/types/event/index.d.ts
@@ -21,6 +21,7 @@ export interface GridEventProps {
   nextValue?: CellValue;
   event?: MouseEvent;
   rowKey?: RowKey | null;
+  rowKeys?: RowKey[] | null;
   columnName?: string | null;
   prevRowKey?: RowKey | null;
   prevColumnName?: string | null;


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

Fixed an issue where multiple checks/unchecks using shift-click did not raise the check/unchecked event. 

When an event is fired due to a single checkbox click, the event handler is passed the same arguments as before, but when an event is fired due to a multiple checkbox check, the event handler is passed `rowKeys` as an argument, which is an array containing all rowKeys instead of `rowKey`.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
