### PR TITLE
fix: move focus on enter regardless cell editable

### DIFF
--- a/packages/toast-ui.grid/cypress/helper/util.ts
+++ b/packages/toast-ui.grid/cypress/helper/util.ts
@@ -6,6 +6,10 @@ export function clipboardType(key: string) {
   cy.getByCls('clipboard').type(key, { force: true });
 }
 
+export function editingLayerType(key: string) {
+  cy.getByCls('layer-editing').type(key);
+}
+
 export function moveToNextPage() {
   cy.get('.tui-page-btn.tui-next').click({ force: true });
 }

--- a/packages/toast-ui.grid/cypress/integration/keyMap.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/keyMap.spec.ts
@@ -1,4 +1,4 @@
-import { clipboardType } from '../helper/util';
+import { clipboardType, editingLayerType } from '../helper/util';
 import { assertFocusedCell, assertSelectedRange } from '../helper/assert';
 import { GridOptions } from '@t/index';
 
@@ -16,10 +16,10 @@ function assertEditFinished() {
 
 function createGrid(options?: Partial<GridOptions>) {
   const data = [
-    { name: 'Han', value: 1 },
-    { name: 'Kim', value: 2 },
-    { name: 'Ryu', value: 3 },
-    { name: 'Lee', value: 4 },
+    { name: 'Han', value: 1, age: 23 },
+    { name: 'Kim', value: 2, age: 28 },
+    { name: 'Ryu', value: 3, age: 27 },
+    { name: 'Lee', value: 4, age: 30 },
   ];
 
   const columns = [
@@ -135,7 +135,13 @@ describe('Focus', () => {
 
 describe('Move focus on enter', () => {
   it('should not move the focus on enter(default)', () => {
-    createGrid();
+    createGrid({
+      columns: [
+        { name: 'name', editor: 'text' },
+        { name: 'value', editor: 'text' },
+        { name: 'age' },
+      ],
+    });
     cy.getCellByIdx(0, 0).click();
 
     clipboardType('{enter}');
@@ -144,53 +150,116 @@ describe('Move focus on enter', () => {
   });
 
   it('should move the focus to next cell on enter(nextCell)', () => {
-    createGrid({ moveDirectionOnEnter: 'nextCell' });
+    createGrid({
+      columns: [
+        { name: 'name', editor: 'text' },
+        { name: 'value', editor: 'text' },
+        { name: 'age' },
+      ],
+      moveDirectionOnEnter: 'nextCell',
+    });
     cy.getCellByIdx(0, 0).click();
 
     clipboardType('{enter}');
 
+    assertFocusedCell('name', 0);
+    cy.getByCls('layer-editing').should('be.visible');
+
+    editingLayerType('{enter}');
+
     assertFocusedCell('value', 0);
+    cy.getByCls('layer-editing').should('be.visible');
+
+    editingLayerType('{enter}');
+
+    assertFocusedCell('age', 0);
+    cy.getByCls('layer-editing').should('be.not.visible');
 
     clipboardType('{enter}');
 
     assertFocusedCell('name', 1);
+    cy.getByCls('layer-editing').should('be.visible');
   });
 
   it('should move the focus to next cell on enter(prevCell)', () => {
-    createGrid({ moveDirectionOnEnter: 'prevCell' });
-    cy.getCellByIdx(1, 1).click();
+    createGrid({
+      columns: [
+        { name: 'name', editor: 'text' },
+        { name: 'value', editor: 'text' },
+        { name: 'age' },
+      ],
+      moveDirectionOnEnter: 'prevCell',
+    });
+    cy.getCellByIdx(1, 0).click();
 
     clipboardType('{enter}');
 
     assertFocusedCell('name', 1);
+    cy.getByCls('layer-editing').should('be.visible');
+
+    editingLayerType('{enter}');
+
+    assertFocusedCell('age', 0);
+    cy.getByCls('layer-editing').should('be.not.visible');
 
     clipboardType('{enter}');
 
     assertFocusedCell('value', 0);
+    cy.getByCls('layer-editing').should('be.visible');
+
+    editingLayerType('{enter}');
+
+    assertFocusedCell('name', 0);
+    cy.getByCls('layer-editing').should('be.visible');
   });
 
   it('should move the focus to next cell on enter(down)', () => {
-    createGrid({ moveDirectionOnEnter: 'down' });
+    createGrid({
+      columns: [
+        { name: 'name', editor: 'text' },
+        { name: 'value', editor: 'text' },
+        { name: 'age' },
+      ],
+      moveDirectionOnEnter: 'down',
+    });
     cy.getCellByIdx(0, 0).click();
 
     clipboardType('{enter}');
 
-    assertFocusedCell('name', 1);
+    assertFocusedCell('name', 0);
+    cy.getByCls('layer-editing').should('be.visible');
 
-    clipboardType('{enter}');
+    editingLayerType('{enter}');
+
+    assertFocusedCell('name', 1);
+    cy.getByCls('layer-editing').should('be.visible');
+
+    editingLayerType('{enter}');
 
     assertFocusedCell('name', 2);
+    cy.getByCls('layer-editing').should('be.visible');
   });
 
   it('should move the focus to next cell on enter(up)', () => {
-    createGrid({ moveDirectionOnEnter: 'up' });
+    createGrid({
+      columns: [
+        { name: 'name', editor: 'text' },
+        { name: 'value', editor: 'text' },
+        { name: 'age' },
+      ],
+      moveDirectionOnEnter: 'up',
+    });
     cy.getCellByIdx(2, 0).click();
 
     clipboardType('{enter}');
 
+    assertFocusedCell('name', 2);
+
+    editingLayerType('{enter}');
+
     assertFocusedCell('name', 1);
 
-    clipboardType('{enter}');
+    editingLayerType('{enter}');
 
     assertFocusedCell('name', 0);
   });

--- a/packages/toast-ui.grid/src/view/clipboard.tsx
+++ b/packages/toast-ui.grid/src/view/clipboard.tsx
@@ -194,9 +194,16 @@ class ClipboardComp extends Component<Props> {
       this.props.eventBus.trigger('keydown', gridEvent);
 
       if (!gridEvent.isStopped()) {
+        const isEditable =
+          keyStroke === 'enter' &&
+          this.context.store &&
+          this.context.store.column.allColumnMap[columnName ?? ''].editor;
+
         this.dispatchKeyboardEvent(
           type,
-          keyStroke === 'enter' && moveDirectionOnEnter ? moveDirectionOnEnter : command
+          keyStroke === 'enter' && moveDirectionOnEnter && !isEditable
+            ? moveDirectionOnEnter
+            : command
         );
       }
     }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

Fixed to start editing in the current cell when the enter key is pressed in a cell that has been edited while using the `moveDirectionOnEnter` option.

**As-Is**

![](https://github.com/nhn/tui.grid/assets/41339744/ad78e018-9a53-4732-9557-41c98d32d21c)

**To-Be**

![](https://github.com/nhn/tui.grid/assets/41339744/b1496d04-2a4b-45af-9f09-b3c123e403c4)



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
