### PR TITLE
feat: improve check between

### DIFF
--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -434,6 +434,25 @@ export function setCheckboxBetween(
 
   const range = getIndexRangeOfCheckbox(store, startRowKey, targetRowKey);
   const checkStateChangedRowkeys = getCheckStateChangedRowkeysInRange(store, value, range);
+  const eventArgs = { rowKey: startRowKey, rowKeys: checkStateChangedRowkeys };
+
+  const gridEventBefore = new GridEvent(eventArgs);
+  /**
+   * Occurs before the http request is sent
+   * @event Grid#beforeRequest
+   * @type {module:event/gridEvent}
+   * @property {XMLHttpRequest} xhr - Current XMLHttpRequest instance
+   * @property {Grid} instance - Current grid instance
+   */
+  eventBus.trigger('beforeCheckBetween', gridEventBefore);
+  if (gridEventBefore.isStopped()) {
+    if (value) {
+      check(store, startRowKey);
+    } else {
+      uncheck(store, startRowKey);
+    }
+    return;
+  }
 
   data.clickedCheckboxRowkey = startRowKey;
 

--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -459,7 +459,7 @@ export function setCheckboxBetween(
   setRowsAttributeInRange(store, 'checked', value, range);
   setCheckedAllRows(store);
 
-  const gridEvent = new GridEvent({ rowKeys: checkStateChangedRowkeys });
+  const gridEvent = new GridEvent(eventArgs);
 
   eventBus.trigger(value ? 'check' : 'uncheck', gridEvent);
 }

--- a/packages/toast-ui.grid/types/options.d.ts
+++ b/packages/toast-ui.grid/types/options.d.ts
@@ -51,6 +51,7 @@ export type GridEventName =
   | 'uncheck'
   | 'checkAll'
   | 'uncheckAll'
+  | 'beforeCheckBetween'
   | 'selection'
   | 'editingStart'
   | 'editingFinish'


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

Added `beforeCheckBetween` event to prevent consecutive checkbox clicks with shift-click. If this is prevented, it will behave the same as normal click behavior(just check or uncheck).

```js
grid.on('beforeCheckBetween`, (e) => e.stop());
```

and added `rowKey` of click row checkbox argument on `checkBetween` event. The `rowKey` is the RowKey of the currently clicked row, which is only useful if the click is with the mouse.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
