### PR TITLE
feat: validate on specific rows

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/validation.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/validation.spec.ts
@@ -64,6 +64,22 @@ describe('should check the validation of cell - regExp', () => {
         },
       ]);
   });
+  it('get validation result of specific rows by validate API', () => {
+    cy.gridInstance()
+      .invoke('validate', [1])
+      .should('eql', [
+        {
+          errors: [
+            {
+              columnName: 'name',
+              errorCode: ['REGEXP'],
+              errorInfo: [{ code: 'REGEXP', regExp: /[0-9]+:[0-9]/ }],
+            },
+          ],
+          rowKey: 1,
+        },
+      ]);
+  });
 });
 
 describe('should check the validation of cell - dataType: string', () => {

--- a/packages/toast-ui.grid/src/grid.tsx
+++ b/packages/toast-ui.grid/src/grid.tsx
@@ -1043,6 +1043,8 @@ export default class Grid implements TuiGrid {
   /**
    * Validate all data and returns the result.
    * Return value is an array which contains only rows which have invalid cell data.
+   * @param {Array<number|string>} [rowKeys] - Array of rowKeys to validate.
+   *        Validate only for the given rows, but validations that should be performed on all rows, such as unique, may not work correctly.
    * @returns {Array.<Object>} An array of error object
    * @example
    * // return value example
@@ -1074,8 +1076,8 @@ export default class Grid implements TuiGrid {
    *     }
    * ]
    */
-  public validate(): InvalidRow[] {
-    return getInvalidRows(this.store);
+  public validate(rowKeys?: RowKey[]): InvalidRow[] {
+    return getInvalidRows(this.store, rowKeys);
   }
 
   /**

--- a/packages/toast-ui.grid/src/query/validation.ts
+++ b/packages/toast-ui.grid/src/query/validation.ts
@@ -1,39 +1,37 @@
 import { Store } from '@t/store';
-import { InvalidRow } from '@t/store/data';
+import { InvalidRow, RowKey } from '@t/store/data';
 import { makeObservable } from '../dispatch/data';
 import { isObservable } from '../helper/observable';
-import { createObservableData } from '../dispatch/lazyObservable';
 
-export function getInvalidRows(store: Store) {
-  // @TODO: find more practical way to make observable
-  createObservableData(store, true);
-
+export function getInvalidRows(store: Store, rowKeys?: RowKey[]) {
   const { data, column } = store;
   const invalidRows: InvalidRow[] = [];
 
   data.rawData.forEach((row, rowIndex) => {
-    if (!isObservable(row)) {
+    if (!isObservable(row) && (!rowKeys || rowKeys.includes(row.rowKey))) {
       makeObservable(store, rowIndex, true);
     }
   });
 
   data.viewData.forEach(({ rowKey, valueMap }) => {
-    const invalidColumns = column.validationColumns.filter(
-      ({ name }) => !!valueMap[name].invalidStates.length
-    );
+    if (!rowKeys || rowKeys?.includes(rowKey)) {
+      const invalidColumns = column.validationColumns.filter(
+        ({ name }) => !!valueMap[name].invalidStates.length
+      );
 
-    if (invalidColumns.length) {
-      const errors = invalidColumns.map(({ name }) => {
-        const { invalidStates } = valueMap[name];
+      if (invalidColumns.length) {
+        const errors = invalidColumns.map(({ name }) => {
+          const { invalidStates } = valueMap[name];
 
-        return {
-          columnName: name,
-          errorInfo: invalidStates,
-          errorCode: invalidStates.map(({ code }) => code),
-        };
-      });
+          return {
+            columnName: name,
+            errorInfo: invalidStates,
+            errorCode: invalidStates.map(({ code }) => code),
+          };
+        });
 
-      invalidRows.push({ rowKey, errors });
+        invalidRows.push({ rowKey, errors });
+      }
     }
   });
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

Added the ability to validate only for certain specified rows.

Passing an array of rowKeys as an argument to the `validate` API will validate only those rows that correspond to the given rowKeys. But validations that should be performed on all rows, such as unique, may not work correctly.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
