### PR TITLE
fix: occur error when call validate with sort

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/validation.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/validation.spec.ts
@@ -529,3 +529,14 @@ describe('should check the validation of cell - unique', () => {
     cy.getCell(1, 'name').should('not.have.class', cls('cell-invalid'));
   });
 });
+
+it('should validate properly after sort', () => {
+  cy.createGrid({
+    data,
+    columns: [{ name: 'name', validation: { required: true }, sortable: true }],
+  });
+
+  cy.gridInstance().invoke('sort', 'name', true);
+
+  cy.gridInstance().invoke('validate').should('be', []);
+});

--- a/packages/toast-ui.grid/src/dispatch/sort.ts
+++ b/packages/toast-ui.grid/src/dispatch/sort.ts
@@ -3,7 +3,7 @@ import { Data, ViewRow, Row } from '@t/store/data';
 import { SortingType } from '@t/store/column';
 import { SortStateResetOption } from '@t/options';
 import { findPropIndex, isUndefined } from '../helper/common';
-import { notify } from '../helper/observable';
+import { notify, unobservable } from '../helper/observable';
 import { sortRawData } from '../helper/sort';
 import { getEventBus } from '../event/eventBus';
 import { updateRowNumber, setCheckedAllRows } from './data';
@@ -41,6 +41,10 @@ function sortData(store: Store) {
     rawData.sort(sortRawData(sortedColumns));
     data.viewData = createSoretedViewData(rawData);
   }
+
+  data.rawData.forEach((rawRow) => {
+    unobservable(rawRow);
+  });
 }
 
 function setInitialSortState(data: Data) {

--- a/packages/toast-ui.grid/src/helper/observable.ts
+++ b/packages/toast-ui.grid/src/helper/observable.ts
@@ -193,6 +193,8 @@ export function unobservable<T extends Dictionary<any>>(obj: T, keys: Array<keyo
 
       obj[key] = originObject[key];
     });
+
+    delete obj.__storage__;
   }
 }
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

Fixed an issue where using the `validate` API with sorting would result in an error.

This was caused by creating the viewDate directly from rawData without unobserving the rows that disappear outside the viewport when sorting.
This caused an error because it thought it was a row that was observable when in fact it was not, and did not convert it to observable.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
