### PR TITLE
fix: finish editing when type enter from last cell when using moveDirectionOnEnter

### DIFF
--- a/packages/toast-ui.grid/cypress/integration/keyMap.spec.ts
+++ b/packages/toast-ui.grid/cypress/integration/keyMap.spec.ts
@@ -263,6 +263,29 @@ describe('Move focus on enter', () => {
 
     assertFocusedCell('name', 0);
   });
+
+  it('should finish editing on last cell', () => {
+    createGrid({
+      columns: [
+        { name: 'name', editor: 'text' },
+        { name: 'value', editor: 'text' },
+        { name: 'age', editor: 'text' },
+      ],
+      moveDirectionOnEnter: 'nextCell',
+    });
+    cy.getCellByIdx(3, 1).click();
+
+    clipboardType('{enter}');
+    editingLayerType('{enter}');
+
+    assertFocusedCell('age', 3);
+    cy.getByCls('layer-editing').should('be.visible');
+
+    editingLayerType('{enter}');
+
+    assertFocusedCell('age', 3);
+    cy.getByCls('layer-editing').should('not.be.visible');
+  });
 });
 
 describe('Selection', () => {

--- a/packages/toast-ui.grid/src/view/editingLayer.tsx
+++ b/packages/toast-ui.grid/src/view/editingLayer.tsx
@@ -58,11 +58,15 @@ export class EditingLayerComp extends Component<Props> {
 
   private longestTextWidths: { [columnName: string]: number } = {};
 
-  private moveTabAndEnterFocus(ev: KeyboardEvent, command: TabCommandType | EnterCommandType) {
+  private moveTabAndEnterFocus(
+    ev: KeyboardEvent,
+    command: TabCommandType | EnterCommandType,
+    moveFocusByEnter = false
+  ) {
     const { dispatch } = this.props;
 
     ev.preventDefault();
-    dispatch('moveTabAndEnterFocus', command);
+    dispatch('moveTabAndEnterFocus', command, moveFocusByEnter);
     dispatch('setScrollToFocus');
   }
 
@@ -75,7 +79,7 @@ export class EditingLayerComp extends Component<Props> {
         if (isUndefined(moveDirectionOnEnter)) {
           this.saveAndFinishEditing(true);
         } else {
-          this.moveTabAndEnterFocus(ev, moveDirectionOnEnter);
+          this.moveTabAndEnterFocus(ev, moveDirectionOnEnter, true);
         }
         break;
       case 'esc':


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

Fixed an issue where typing Enter in the last cell (when there are no more cells to move) would not complete the edit when using the `moveDirectionOnEnter` option.

**As-Is**

![](https://github.com/nhn/tui.grid/assets/41339744/8f24f7c7-8e8e-4211-bb41-223e844318b7)

**To-Be**

![](https://github.com/nhn/tui.grid/assets/41339744/c39c69f1-1768-4bd9-a81b-8228c28c13e1)


Fixed an issue where typing Enter in the last cell (when there are no more cells to move) would not complete the edit when using the `moveDirectionOnEnter` option.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
